### PR TITLE
fix compiling debug build using clang #35

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -71,7 +71,7 @@ void set_debug_level (int level) {
 	debug_level = level;
 }
 
-inline int get_debug_level (void) {
+int get_debug_level (void) {
 	return (debug_level);
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -37,7 +37,7 @@
 void debug_int(const char* file, int line, const char* function, int level, const char* fmt, ...);
 void debug_cmd(int, char *[], char *, ...);
 void set_debug_level (int);
-inline int get_debug_level (void);
+int get_debug_level (void);
 
 int debug_increase_indent(void);
 int debug_decrease_indent(void);


### PR DESCRIPTION
clang doesn't allow inline on function in external file.

http://clang.llvm.org/compatibility.html#inline suggests removing the `inline` if needed by multiple translation units.
