### PR TITLE
bury xmms support six feet under, fix #149

### DIFF
--- a/src/pref.c
+++ b/src/pref.c
@@ -3943,6 +3943,59 @@ static GtkWidget *general_options_page (void) {
 
 	gtk_widget_show (hbox);
 
+	/* When launching a Game */
+
+	frame = gtk_frame_new (_("When launching a game..."));
+	gtk_box_pack_start (GTK_BOX (page_vbox), frame, FALSE, FALSE, 0);
+
+	vbox = gtk_vbox_new (FALSE, 2);
+	gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
+	gtk_container_add (GTK_CONTAINER (frame), vbox);
+
+	/* Terminate */
+
+	hbox = gtk_hbox_new (FALSE, 4);
+	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
+
+	terminate_check_button = gtk_check_button_new_with_label (_("Terminate XQF"));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (terminate_check_button), default_terminate);
+	gtk_signal_connect (GTK_OBJECT (terminate_check_button), "toggled", GTK_SIGNAL_FUNC (terminate_toggled_callback), NULL);
+	gtk_box_pack_start (GTK_BOX (hbox), terminate_check_button, FALSE, FALSE, 0);
+	gtk_widget_show (terminate_check_button);
+
+	gtk_widget_show (hbox);
+
+	/* Launchinfo */
+
+	hbox = gtk_hbox_new (FALSE, 4);
+	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
+
+	launchinfo_check_button = gtk_check_button_new_with_label (_("Create LaunchInfo.txt"));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (launchinfo_check_button), default_launchinfo);
+	gtk_signal_connect (GTK_OBJECT (launchinfo_check_button), "toggled", GTK_SIGNAL_FUNC (launchinfo_toggled_callback), NULL);
+	gtk_box_pack_start (GTK_BOX (hbox), launchinfo_check_button, FALSE, FALSE, 0);
+	gtk_tooltips_set_tip (tooltips, launchinfo_check_button, _("Creates the file ~/.config/xqf/LaunchInfo.txt with: ping ip:port name map curplayers maxplayers"), NULL);
+	gtk_widget_show (launchinfo_check_button);
+
+	gtk_widget_show (hbox);
+
+	/* Prelaunchinfo */
+
+	hbox = gtk_hbox_new (FALSE, 4);
+	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
+
+	prelaunchexec_check_button = gtk_check_button_new_with_label (_("Execute prelaunch"));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (prelaunchexec_check_button), default_prelaunchexec);
+	gtk_signal_connect (GTK_OBJECT (prelaunchexec_check_button), "toggled", GTK_SIGNAL_FUNC (prelaunchexec_toggled_callback), NULL);
+	gtk_box_pack_start (GTK_BOX (hbox), prelaunchexec_check_button, FALSE, FALSE, 0);
+	gtk_tooltips_set_tip (tooltips, prelaunchexec_check_button, _("Executes ~/.config/xqf/PreLaunch (if it exists) before launching the game"), NULL);
+	gtk_widget_show (prelaunchexec_check_button);
+
+	gtk_widget_show (hbox);
+
+	gtk_widget_show (vbox);
+	gtk_widget_show (frame);
+
 	/* On Exit */
 
 	frame = gtk_frame_new (_("On Exit"));
@@ -3991,59 +4044,6 @@ static GtkWidget *general_options_page (void) {
 	}
 
 	gtk_widget_show (save_plrinfo_check_button);
-
-	gtk_widget_show (hbox);
-
-	gtk_widget_show (vbox);
-	gtk_widget_show (frame);
-
-	/* When launching a Game */
-
-	frame = gtk_frame_new (_("When launching a game..."));
-	gtk_box_pack_start (GTK_BOX (page_vbox), frame, FALSE, FALSE, 0);
-
-	vbox = gtk_vbox_new (FALSE, 2);
-	gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
-	gtk_container_add (GTK_CONTAINER (frame), vbox);
-
-	/* Terminate */
-
-	hbox = gtk_hbox_new (FALSE, 4);
-	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
-
-	terminate_check_button = gtk_check_button_new_with_label (_("Terminate XQF"));
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (terminate_check_button), default_terminate);
-	gtk_signal_connect (GTK_OBJECT (terminate_check_button), "toggled", GTK_SIGNAL_FUNC (terminate_toggled_callback), NULL);
-	gtk_box_pack_start (GTK_BOX (hbox), terminate_check_button, FALSE, FALSE, 0);
-	gtk_widget_show (terminate_check_button);
-
-	gtk_widget_show (hbox);
-
-	/* Launchinfo */
-
-	hbox = gtk_hbox_new (FALSE, 4);
-	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
-
-	launchinfo_check_button = gtk_check_button_new_with_label (_("Create LaunchInfo.txt"));
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (launchinfo_check_button), default_launchinfo);
-	gtk_signal_connect (GTK_OBJECT (launchinfo_check_button), "toggled", GTK_SIGNAL_FUNC (launchinfo_toggled_callback), NULL);
-	gtk_box_pack_start (GTK_BOX (hbox), launchinfo_check_button, FALSE, FALSE, 0);
-	gtk_tooltips_set_tip (tooltips, launchinfo_check_button, _("Creates the file ~/.config/xqf/LaunchInfo.txt with: ping ip:port name map curplayers maxplayers"), NULL);
-	gtk_widget_show (launchinfo_check_button);
-
-	gtk_widget_show (hbox);
-
-	/* Prelaunchinfo */
-
-	hbox = gtk_hbox_new (FALSE, 4);
-	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
-
-	prelaunchexec_check_button = gtk_check_button_new_with_label (_("Execute prelaunch"));
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (prelaunchexec_check_button), default_prelaunchexec);
-	gtk_signal_connect (GTK_OBJECT (prelaunchexec_check_button), "toggled", GTK_SIGNAL_FUNC (prelaunchexec_toggled_callback), NULL);
-	gtk_box_pack_start (GTK_BOX (hbox), prelaunchexec_check_button, FALSE, FALSE, 0);
-	gtk_tooltips_set_tip (tooltips, prelaunchexec_check_button, _("Executes ~/.config/xqf/PreLaunch (if it exists) before launching the game"), NULL);
-	gtk_widget_show (prelaunchexec_check_button);
 
 	gtk_widget_show (hbox);
 

--- a/src/pref.c
+++ b/src/pref.c
@@ -93,7 +93,6 @@ int serverlist_countbots;
 
 int default_terminate;
 int default_launchinfo;
-int default_stopxmms;
 int default_prelaunchexec;
 int default_save_lists;
 int default_save_srvinfo;
@@ -168,7 +167,6 @@ static GtkWidget *qw_bottom_color_button;
 
 static GtkWidget *terminate_check_button;
 static GtkWidget *launchinfo_check_button;
-static GtkWidget *stopxmms_check_button;
 static GtkWidget *prelaunchexec_check_button;
 static GtkWidget *save_lists_check_button;
 static GtkWidget *save_srvinfo_check_button;
@@ -1231,11 +1229,6 @@ static void get_new_defaults (void) {
 	i = GTK_TOGGLE_BUTTON (launchinfo_check_button)->active;
 	if (i != default_launchinfo) {
 		config_set_bool ("launchinfo", default_launchinfo = i);
-	}
-
-	i = GTK_TOGGLE_BUTTON (stopxmms_check_button)->active;
-	if (i != default_stopxmms) {
-		config_set_bool ("stopxmms", default_stopxmms = i);
 	}
 
 	i = GTK_TOGGLE_BUTTON (prelaunchexec_check_button)->active;
@@ -3897,7 +3890,6 @@ static GtkWidget *general_options_page (void) {
 	GtkWidget *frame;
 	GtkWidget *hbox;
 	GtkWidget *vbox;
-	GtkWidget *table;
 
 	page_vbox = gtk_vbox_new (FALSE, 4);
 	gtk_container_set_border_width (GTK_CONTAINER (page_vbox), 8);
@@ -4016,16 +4008,13 @@ static GtkWidget *general_options_page (void) {
 
 	/* Terminate */
 
-	table = gtk_table_new(3,2,TRUE);
-
-	gtk_box_pack_start (GTK_BOX (vbox), table, FALSE, FALSE, 0);
+	hbox = gtk_hbox_new (FALSE, 4);
+	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
 
 	terminate_check_button = gtk_check_button_new_with_label (_("Terminate XQF"));
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (terminate_check_button), default_terminate);
 	gtk_signal_connect (GTK_OBJECT (terminate_check_button), "toggled", GTK_SIGNAL_FUNC (terminate_toggled_callback), NULL);
-
-	gtk_table_attach_defaults(GTK_TABLE(table),terminate_check_button, 0, 1, 0, 1);
-
+	gtk_box_pack_start (GTK_BOX (hbox), terminate_check_button, FALSE, FALSE, 0);
 	gtk_widget_show (terminate_check_button);
 
 	gtk_widget_show (hbox);
@@ -4038,41 +4027,31 @@ static GtkWidget *general_options_page (void) {
 	launchinfo_check_button = gtk_check_button_new_with_label (_("Create LaunchInfo.txt"));
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (launchinfo_check_button), default_launchinfo);
 	gtk_signal_connect (GTK_OBJECT (launchinfo_check_button), "toggled", GTK_SIGNAL_FUNC (launchinfo_toggled_callback), NULL);
-	gtk_table_attach_defaults(GTK_TABLE(table),launchinfo_check_button, 0, 1, 1, 2);
+	gtk_box_pack_start (GTK_BOX (hbox), launchinfo_check_button, FALSE, FALSE, 0);
 	gtk_tooltips_set_tip (tooltips, launchinfo_check_button, _("Creates the file ~/.config/xqf/LaunchInfo.txt with: ping ip:port name map curplayers maxplayers"), NULL);
 	gtk_widget_show (launchinfo_check_button);
 
+	gtk_widget_show (hbox);
+
 	/* Prelaunchinfo */
+
+	hbox = gtk_hbox_new (FALSE, 4);
+	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
 
 	prelaunchexec_check_button = gtk_check_button_new_with_label (_("Execute prelaunch"));
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (prelaunchexec_check_button), default_prelaunchexec);
 	gtk_signal_connect (GTK_OBJECT (prelaunchexec_check_button), "toggled", GTK_SIGNAL_FUNC (prelaunchexec_toggled_callback), NULL);
+	gtk_box_pack_start (GTK_BOX (hbox), prelaunchexec_check_button, FALSE, FALSE, 0);
 	gtk_tooltips_set_tip (tooltips, prelaunchexec_check_button, _("Executes ~/.config/xqf/PreLaunch (if it exists) before launching the game"), NULL);
 	gtk_widget_show (prelaunchexec_check_button);
 
-	gtk_table_attach_defaults(GTK_TABLE(table),prelaunchexec_check_button, 1, 2, 1, 2);
-
-
-	/* Stop XMMS */
-
-	stopxmms_check_button = gtk_check_button_new_with_label (_("Stop current song in XMMS"));
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (stopxmms_check_button), default_stopxmms);
-	gtk_tooltips_set_tip (tooltips, stopxmms_check_button, _("Stopping XMMS will release /dev/dsp. "
-		"Activate this option if you use XMMS and have a cheap soundcard "
-		"that allows only one application to open /dev/dsp."), NULL);
-	gtk_widget_show (stopxmms_check_button);
-
-	gtk_table_attach_defaults(GTK_TABLE(table),stopxmms_check_button, 0, 1, 2, 3);
-
-
-	gtk_widget_show(table);
-
 	gtk_widget_show (hbox);
-	gtk_widget_show (vbox);
 
+	gtk_widget_show (vbox);
 	gtk_widget_show (frame);
 
 	gtk_widget_show (hbox);
+	gtk_widget_show (vbox);
 	gtk_widget_show (frame);
 
 	gtk_widget_show (page_vbox);
@@ -5041,7 +5020,6 @@ int prefs_load (void) {
 
 	default_terminate =         config_get_bool("terminate=false");
 	default_launchinfo =        config_get_bool("launchinfo=true");
-	default_stopxmms =          config_get_bool("stopxmms=false");
 	default_prelaunchexec =     config_get_bool("prelaunchexec=false");
 	default_save_lists =        config_get_bool("save lists=true");
 	default_save_srvinfo =      config_get_bool("save srvinfo=true");

--- a/src/xqf.c
+++ b/src/xqf.c
@@ -1022,49 +1022,6 @@ static gboolean check_launch (struct condef* con) {
 	return FALSE;
 }
 
-// stop XMMS if running
-static void stopxmms () {
-	char* xmmssocket = NULL;
-	pid_t pid;
-
-	if (!default_stopxmms) {
-		return;
-	}
-
-	xmmssocket = g_strdup_printf ("/tmp/xmms_%s.0", g_get_user_name ());
-
-	if (access (xmmssocket, R_OK)) {
-		debug (3, "xmms not running");
-		g_free (xmmssocket);
-		return;
-	}
-
-	pid = fork ();
-	if (pid == 0) {
-		char *argv[3];
-		argv[0] = "xmms";
-		argv[1] = "-s";
-		argv[2] = NULL;
-		execvp (argv[0], argv);
-		_exit (EXIT_FAILURE);
-	}
-	else if (pid > 0) {
-		int status;
-		waitpid (pid,&status,0);
-
-		if (WIFEXITED (status)) {
-			debug (3, "xmms exited normally");
-		}
-		else {
-			debug (3, "xmms exited with status %d", WEXITSTATUS (status));
-		}
-		if (WIFSIGNALED (status)) {
-			debug (3, "xmms was killed by signal %d", WTERMSIG (status));
-		}
-	}
-
-	g_free (xmmssocket);
-}
 
 static void launch_close_handler_part2 (struct condef *con) {
 	struct server_props *props;
@@ -1077,8 +1034,6 @@ static void launch_close_handler_part2 (struct condef *con) {
 	char *temp_game;
 
 	struct server *s;
-
-	stopxmms ();
 
 	if (redialserver == 1) // was called from a redial
 		play_sound (sound_redial_success, 0);


### PR DESCRIPTION
This patch removes the XMMS support.

Before:

![XQF with XMMS support](http://dl.illwieckz.net/u/thomas-debesse/bug-reports/xqf/149-xmms/20150619-204944-xqf-xmms.png)

After:

![XQF without XMMS support](http://dl.illwieckz.net/u/thomas-debesse/bug-reports/xqf/149-xmms/20150619-222010-xqf-no-xmms.png)

This patch fixes #149 .