### PR TITLE
re-enabling the savage hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,9 @@ add_custom_command (TARGET translation
 # Executable
 install (TARGETS xqf DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
+# Query script
+install (PROGRAMS ${CMAKE_SOURCE_DIR}/src/script/qstat_savage.sh DESTINATION "${PACKAGE_DATA_DIR}/script")
+
 # UI
 install (FILES ${CMAKE_SOURCE_DIR}/src/xqf.ui DESTINATION ${PACKAGE_DATA_DIR}/ui)
 
@@ -380,7 +383,7 @@ endforeach (SIZE ${icon_SIZE})
 install (FILES ${CMAKE_SOURCE_DIR}/pixmaps/scalable/xqf.svg DESTINATION ${PIXMAPS_ENTRY_PATH}/scalable/apps)
 
 # Config
-install (FILES ${CMAKE_SOURCE_DIR}/src/qstat.cfg ${CMAKE_SOURCE_DIR}/src/qstat_savage.sh DESTINATION ${PACKAGE_DATA_DIR})
+install (FILES ${CMAKE_SOURCE_DIR}/src/qstat.cfg DESTINATION ${PACKAGE_DATA_DIR})
 
 # Man pages
 install (FILES ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.6 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man6)

--- a/src/script/qstat_savage.sh
+++ b/src/script/qstat_savage.sh
@@ -1,12 +1,24 @@
 #! /bin/sh
 
-#url="http://masterserver.savage.s2games.com/gamelist_full.dat"
-url="$1"
-
-if [ "x${url}" = 'x' ]
+if [ "x${1}" = 'x' -o "x${1}" = 'x--help' ]
 then
+	printf 'Usage: %s -sam http://masterserver.savage.s2games.com/gamelist_full.dat\n' "${0}"
 	exit
 fi
+
+if [ "x${2}" = 'x' ]
+then
+	printf 'missing argument for "%s"\n' "${1}"
+	exit
+fi
+
+if [ "x${1}" != 'x-sam' ]
+then
+	printf 'unknown option "%s"\n' "${1}"
+	exit
+fi
+
+url="${2}"
 
 http_helper="wget -t 1 -T 20 -q -e robots=off --user-agent=XQF -O -"
 server_type="SAS"

--- a/src/stat.c
+++ b/src/stat.c
@@ -1061,9 +1061,10 @@ static struct stat_conn *stat_update_master_qstat (struct stat_job *job, struct 
 
 		/* savage hack */
 		if (m->type == SAS_SERVER) {
-			argv[argi++] = "sh";
-			argv[argi++] = QSTAT_SAVAGE_SCRIPT;
+			argv[argi++] = PACKAGE_DATA_DIR "/script/qstat_savage.sh";
+			argv[argi++] = "-sam";
 			argv[argi++] = m->url;
+			argv[argi++] = NULL;
 		}
 		else if (m->master_type == MASTER_GSLIST) {
 			int ret = 0;

--- a/src/stat.h
+++ b/src/stat.h
@@ -31,10 +31,6 @@
 # define HTTP_HELPER        "wget -t 1 -T 20 -q -e robots=off --user-agent=XQF/" XQF_VERSION " -O -"
 #endif
 
-#ifndef QSTAT_SAVAGE_SCRIPT
-#define QSTAT_SAVAGE_SCRIPT "qstat_savage.sh"
-#endif
-
 #define QSTAT_DELIM         '\t'
 #define QSTAT_DELIM_STR     "\t"
 #define QSTAT_MASTER_DELIM  ' '


### PR DESCRIPTION
So, this patch re-enable the savage hack. The savage hack is is a very ugly workaround that replaces an older very ugly workaround. I want to add savage master support to qstat (see https://github.com/multiplay/qstat/issues/6 and #110 ) but I have no time to do it right now so the easier is to keep this workaround to avoid regression.

Also, this patch fixes a bug (a list was not terminated); before this fix, the patch was usable only by lucky people.