### PR TITLE
re-enable map screenshot preview, fix minizip SIGSEGV, fix #141, ref #163

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -41,11 +41,6 @@ static int destroy_on_escape (GtkWidget *widget, GdkEventKey *event) {
 	return FALSE;
 }
 
-static int unregister_window_callback (GtkWidget *widget, GdkEventKey *event) {
-	unregister_window(widget);
-	return FALSE;
-}
-
 GtkWidget *dialog_create_modal_transient_window (const char *title,
 		int close_on_esc,
 		int allow_resize,
@@ -473,8 +468,6 @@ char *enter_string_with_option_dialog (int visible, char *optstr, int *optval, c
 
 	return res;
 }
-
-static GtkWidget* create_AboutWindow (void);
 
 void about_dialog (GtkWidget *widget, gpointer data) {
 	const gchar *authors[] = {

--- a/src/pref.c
+++ b/src/pref.c
@@ -3644,21 +3644,15 @@ void add_t2_options_to_notebook(GtkWidget *notebook, enum server_type type) {
 }
 
 static void terminate_toggled_callback (GtkWidget *widget, gpointer data) {
-	int val;
-
-	val = GTK_TOGGLE_BUTTON (terminate_check_button)->active;
+	GTK_TOGGLE_BUTTON (terminate_check_button)->active;
 }
 
 static void launchinfo_toggled_callback (GtkWidget *widget, gpointer data) {
-	int val;
-
-	val = GTK_TOGGLE_BUTTON (launchinfo_check_button)->active;
+	GTK_TOGGLE_BUTTON (launchinfo_check_button)->active;
 }
 
 static void prelaunchexec_toggled_callback (GtkWidget *widget, gpointer data) {
-	int val;
-
-	val = GTK_TOGGLE_BUTTON (prelaunchexec_check_button)->active;
+	GTK_TOGGLE_BUTTON (prelaunchexec_check_button)->active;
 }
 
 /** make entries editable if yes == TRUE */
@@ -5080,7 +5074,6 @@ int prefs_load (void) {
 static void scan_maps_for(enum server_type type) {
 	// translator: %s = game name, e.g. Quake 3 Arena
 	char* msg = g_strdup_printf(_("Searching for %s maps"),games[type].name);
-	guint per = 100/GAMES_TOTAL;
 
 	if (games[type].init_maps) {
 		games[type].init_maps(games[type].type);

--- a/src/pref.c
+++ b/src/pref.c
@@ -3935,6 +3935,9 @@ static GtkWidget *general_options_page (void) {
 
 	gtk_widget_show (hbox);
 
+	gtk_widget_show (vbox);
+	gtk_widget_show (frame);
+
 	/* When launching a Game */
 
 	frame = gtk_frame_new (_("When launching a game..."));


### PR DESCRIPTION
* The map scanning options were in the code but was'nt displayed, due to a mistake when the splash screen code was removed (see #93, #109).

* Also, since the code use an external minizip (see #147, #141), I got a bug which is on some minizip release, XQF got SIGSEGV on unzGetCurrentFileInfo when used with some NULL pointer parameters, so I just added useless real pointers and it works.

* I've also made some cleaning of unused code.

So, without this fix, if the "scan at startup" option is activated, XQF crash at startup even if the option was not visible in the preference window.