### PR TITLE
Callbacks separation, GtkProgressBar upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_definitions (-DQSTAT_EXEC="${WITH_QSTAT}")
 
 if (CMAKE_BUILD_TYPE MATCHES DEBUG)
 	add_definitions (-DDEBUG)
+	set (CMAKE_C_FLAGS "-g -ggdb -O0")
 endif (CMAKE_BUILD_TYPE MATCHES DEBUG)
 
 # Default GUI setting
@@ -79,6 +80,7 @@ set (xqf_SOURCES
 
      ${CMAKE_SOURCE_DIR}/src/addmaster.c
      ${CMAKE_SOURCE_DIR}/src/addserver.c
+     ${CMAKE_SOURCE_DIR}/src/callbacks.c
      ${CMAKE_SOURCE_DIR}/src/config.c
      ${CMAKE_SOURCE_DIR}/src/country-filter.c
      ${CMAKE_SOURCE_DIR}/src/debug.c
@@ -118,9 +120,11 @@ set (xqf_SOURCES
 
      ${CMAKE_SOURCE_DIR}/src/addmaster.h
      ${CMAKE_SOURCE_DIR}/src/addserver.h
+     ${CMAKE_SOURCE_DIR}/src/callbacks.h
      ${CMAKE_SOURCE_DIR}/src/config.h
      ${CMAKE_SOURCE_DIR}/src/country-filter.h
      ${CMAKE_SOURCE_DIR}/src/debug.h
+     ${CMAKE_SOURCE_DIR}/src/defs.h
      ${CMAKE_SOURCE_DIR}/src/dialogs.h
      ${CMAKE_SOURCE_DIR}/src/dns.h
      ${CMAKE_SOURCE_DIR}/src/filter.h

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,0 +1,174 @@
+// XQF Game Server Browser
+// Copyright (C) 1998-2015 XQF Team - https://xqf.github.io
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+
+#include <stdio.h>
+
+#include <libintl.h>
+#include <locale.h>
+
+#include <glib.h>
+#include <gtk/gtk.h>
+
+#include "debug.h"
+#include "filter.h"
+#include "pref.h"
+#include "source.h"
+#include "server.h"
+#include "srv-list.h"
+#include "stat.h"
+#include "xqf-ui.h"
+
+void reset_main_status_bar (GtkBuilder *builder) {
+	// Reset bottom left status bar to show number of servers
+	print_status (GTK_WIDGET (gtk_builder_get_object (builder, "main-status-bar")), ngettext("%d server", "%d servers", server_clist->rows), server_clist->rows);
+}
+
+void set_widgets_sensitivity (GtkBuilder *builder) {
+	GList *selected = server_clist->selection;
+	int sens;
+	int i;
+	int source_is_favorites;
+	int masters_to_update;
+	int masters_to_delete;
+
+	// Every button with callback that can modify its sensitivity
+	// should be explicitly put to GTK_STATE_NORMAL state before
+	// changing its insensitivity
+
+	source_is_favorites = (cur_source != NULL && cur_source->next == NULL && (struct master *) cur_source->data == favorites);
+
+	if (source_is_favorites) {
+		masters_to_update = masters_to_delete = FALSE;
+	}
+	else {
+		masters_to_update = source_has_masters_to_update (cur_source);
+		masters_to_delete = source_has_masters_to_delete (cur_source);
+	}
+
+	sens = (!stat_process && cur_server);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_properties_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_properties_menu_item")), sens);
+
+	sens = (!stat_process && cur_server && (games[cur_server->type].flags & GAME_CONNECT) != 0);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "connect_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_connect_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "connect-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "connect-button")), sens);
+
+	sens = (!stat_process && cur_server && (games[cur_server->type].flags & GAME_SPECTATE) != 0 && (cur_server->flags & SERVER_SPECTATE) != 0);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "observe_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_observe_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "observe-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "observe-button")), sens);
+
+	sens = (!stat_process && cur_server && (games[cur_server->type].flags & GAME_RECORD) != 0);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "record_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_record_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "record-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "record-button")), sens);
+
+	sens = (!stat_process && cur_server && (games[cur_server->type].flags & GAME_RCON) != 0);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "rcon_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_rcon_menu_item")), sens);
+
+	sens = (!stat_process && selected);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "refrsel_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "view_refrsel_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "refrsel-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "refrsel-button")), sens);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "resolve_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_resolve_menu_item")), sens);
+
+	sens = (!stat_process);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "file_statistics_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "add_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_add_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_update_master_builtin_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_update_master_gslist_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_add_master_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_find_player_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_find_again_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "player_filter_menu_item")), sens);
+	gtk_widget_set_sensitive (source_ctree, sens);
+
+	sens = (!stat_process && selected && !source_is_favorites);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "favadd_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_favadd_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "server_favadd_menu_item")), sens);
+
+	sens = (!stat_process && masters_to_delete);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_delete_master_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_clear_master_servers_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "source_delete_master_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "source_clear_master_servers_menu_item")), sens);
+
+	// you can only edit one server a time, no groups and no favorites
+	sens = (cur_source && cur_source->next == NULL && ! ((struct master *) cur_source->data)->isgroup && ! source_is_favorites);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "source_edit_master_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "edit_edit_master_menu_item")), sens);
+
+	sens = (!stat_process && (server_clist->rows > 0));
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "refresh_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "view_refresh_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "refresh-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "refresh-button")), sens);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "view_hostnames_menu_item")), sens);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "view_defport_menu_item")), sens);
+
+	sens = (!stat_process && masters_to_update);
+
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "view_update_menu_item")), sens);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "update-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "update-button")), sens);
+
+	sens = (stat_process != NULL);
+
+	gtk_widget_set_state     (GTK_WIDGET (gtk_builder_get_object (builder, "stop-button")), GTK_STATE_NORMAL);
+	gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, "stop-button")), sens);
+
+	sens = (stat_process == NULL);
+
+	for (i = 0; i < FILTERS_TOTAL; i++) {
+		if (!filter_buttons[i]) {
+			continue;
+		}
+		gtk_widget_set_state (filter_buttons[i], GTK_STATE_NORMAL);
+		gtk_widget_set_sensitive (filter_buttons[i], sens);
+		if (GTK_IS_TOGGLE_BUTTON (filter_buttons[i]) && GTK_TOGGLE_BUTTON (filter_buttons[i])->active) {
+			gtk_widget_set_state (filter_buttons[i], GTK_STATE_ACTIVE);
+		}
+	}
+}

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -1,0 +1,27 @@
+// XQF Game Server Browser
+// Copyright (C) 1998-2015 XQF Team - https://xqf.github.io
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+
+#include <stdio.h>
+
+#include <libintl.h>
+#include <locale.h>
+
+#include <glib.h>
+#include <gtk/gtk.h>
+
+void reset_main_status_bar (GtkBuilder *builder);
+void set_widgets_sensitivity (GtkBuilder *builder);

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,0 +1,234 @@
+// XQF Game Server Browser
+// Copyright (C) 1998-2015 XQF Team - https://xqf.github.io
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+
+#ifndef __DEFS_H__
+#define __DEFS_H__
+
+#include <sys/types.h>
+#include <netinet/in.h>     /* struct in_addr */
+#include <arpa/inet.h>      /* struct in_addr */
+#include <time.h>           /* time_t */
+
+#include <gtk/gtk.h>
+#include <glib.h>
+
+// max 0x8000, server->flags is unsigned
+enum server_flags {
+	PLAYER_GROUP_RED =      0x001,
+	PLAYER_GROUP_GREEN =    0x002,
+	PLAYER_GROUP_BLUE =     0x004,
+	PLAYER_GROUP_MASK =     0x007,
+
+	SERVER_CHEATS =         0x008,
+	SERVER_PASSWORD =       0x010,
+	SERVER_SP_PASSWORD =    0x020,
+	SERVER_SPECTATE =       0x040,
+	SERVER_PUNKBUSTER =     0x080,
+	SERVER_INCOMPATIBLE =   0x100
+};
+
+enum launch_mode {
+	LAUNCH_NORMAL,
+	LAUNCH_SPECTATE,
+	LAUNCH_RECORD
+};
+
+
+// note: there is a limit of 256 servers, see get_server_pixmap in srv-list.c
+enum server_type {
+	Q1_SERVER = 0,
+	QW_SERVER,
+	Q2_SERVER,
+	Q3_SERVER,
+	Q4_SERVER,
+	WO_SERVER,
+	WOET_SERVER,
+	ETL_SERVER,
+	DOOM3_SERVER,
+	ETQW_SERVER,
+	EF_SERVER,
+	H2_SERVER,
+	HW_SERVER,
+	SN_SERVER,
+	HL_SERVER_OLD,
+	HL_SERVER,
+	HL2_SERVER,
+	KP_SERVER,
+	SFS_SERVER,
+	SOF2S_SERVER,
+	T2_SERVER,
+	HR_SERVER,
+	UN_SERVER,
+	UT2_SERVER,
+	UT2004_SERVER,
+	RUNE_SERVER,
+	POSTAL2_SERVER,
+	AAO_SERVER,
+	DESCENT3_SERVER,
+	SSAM_SERVER,
+	SSAMSE_SERVER,
+	MOHAA_SERVER,
+	COD_SERVER,
+	SAS_SERVER,
+	BF1942_SERVER,
+	JK2_SERVER,
+	JK3_SERVER,
+	NETP_SERVER,
+	NEXUIZ_SERVER,
+	XONOTIC_SERVER,
+	WARSOW_SERVER,
+	TREMULOUS_SERVER,
+	TREMULOUSGPP_SERVER,
+	TREMFUSION_SERVER,
+	UNVANQUISHED_SERVER,
+	OPENARENA_SERVER,
+	OTTD_SERVER,
+	Q3RALLY_SERVER,
+	WOP_SERVER,
+	IOURT_SERVER,
+	REACTION_SERVER,
+	SMOKINGUNS_SERVER,
+	ZEQ2LITE_SERVER,
+	TURTLEARENA_SERVER,
+	ALIENARENA_SERVER,
+	GPS_SERVER,
+	UNKNOWN_SERVER
+};
+
+#define GAMES_TOTAL UNKNOWN_SERVER
+
+enum master_state {
+	SOURCE_NA = 0,
+	SOURCE_UP,
+	SOURCE_DOWN,
+	SOURCE_TIMEOUT,
+	SOURCE_ERROR
+};
+
+enum master_query_type {
+	MASTER_NATIVE=0,
+	MASTER_GAMESPY,
+	MASTER_HTTP,
+	MASTER_LAN,
+	MASTER_FILE,
+	MASTER_GSLIST,
+	MASTER_NUM_QUERY_TYPES,
+	MASTER_INVALID_TYPE
+};
+
+// A player. There is no destructor for this struct. Alloc as many data as you need at once and have the pointers point inside.
+
+struct player {
+	char *name;
+	char *skin;
+	char *model;
+	int time;
+	short frags;
+	short ping;
+	unsigned char shirt;
+	unsigned char pants;
+	unsigned char flags;
+};
+
+struct host {
+	char *name;
+	struct in_addr ip;
+	time_t refreshed;
+	int ref_count;
+};
+
+
+// server_new, server_free_info, server_move_info must be adapted for changes to this structure
+
+struct server {
+	struct host *host;
+
+	gchar *name;
+	char *map;
+	char **info;
+	char *game;         // pointer into info, do not free
+	char *gametype;     // pointer into info, do not free
+	GSList *players;    // GSList<struct player *>
+
+#ifdef USE_GEOIP
+	int country_id;
+#endif
+
+	unsigned flags;
+
+	unsigned flt_last;  // time of the last filtering
+
+	time_t refreshed;
+	time_t last_answer; // time of last reply from server
+
+	int ref_count;
+
+	enum server_type type;
+	unsigned short port;
+
+	unsigned short maxplayers;
+	unsigned short curplayers;
+	unsigned short curbots;
+	unsigned short private_client;  // number of private clients
+	short ping;
+	short retries;
+
+	char sv_os;             // L = Linux, W = windows, M = Mac
+
+	unsigned char filters;
+	unsigned char flt_mask;
+};
+
+struct userver {
+	char *hostname;
+	struct server *s;
+	int ref_count;
+	unsigned short port;
+	unsigned char type;     // enum server_type type;
+};
+
+typedef struct {
+	int portadjust;         // value added to port
+	char* gsmtype;          // type for gslist master
+} QFMasterOptions;
+
+typedef struct master {
+	char *name;
+	enum server_type type;
+	int isgroup;            // is it a real master or master group?
+	int user;               // is it added or edited by user?
+	QFMasterOptions options;
+
+	struct host *host;
+	unsigned short port;
+	char *hostname;         // unresolved hostname
+
+	char *url;
+
+	GSList *servers;
+	GSList *uservers;
+	enum master_state state;
+
+	GSList *masters;
+
+	enum master_query_type master_type;
+
+	// private
+	char* _qstat_master_option; // optional override from games[type].qstat_master_option
+} QFMaster;
+
+#endif //__DEFS_H__

--- a/src/psearch.c
+++ b/src/psearch.c
@@ -390,7 +390,7 @@ void find_player (int find_next) {
 
 	if (!find_next || server_clist->selection == NULL) {
 		dialog_ok (NULL, _("Player not found."));
-		reset_main_status_bar();
+		reset_main_status_bar(builder);
 	}
 	else {
 		if (dialog_yesno (_("XQF: End of server list reached"), 0, _("Yes"), _("No"),
@@ -398,6 +398,6 @@ void find_player (int find_next) {
 			find_player (FALSE);
 		}
 		else
-			reset_main_status_bar();
+			reset_main_status_bar(builder);
 	}
 }

--- a/src/srv-list.c
+++ b/src/srv-list.c
@@ -425,7 +425,7 @@ void server_clist_sync_selection (void) {
 		player_clist_set_server (cur_server);
 		srvinf_ctree_set_server (cur_server);
 
-		set_widgets_sensitivity ();
+		set_widgets_sensitivity (builder);
 	}
 }
 

--- a/src/xqf-ui.h
+++ b/src/xqf-ui.h
@@ -22,7 +22,8 @@
 #include <gtk/gtk.h>
 
 #include "xqf.h"
-
+#include "callbacks.h"
+#include "filter.h"
 
 struct clist_column {
 	const char *name;
@@ -80,8 +81,6 @@ extern void register_window (GtkWidget *window);
 extern void unregister_window (GtkWidget *window);
 extern GtkWidget *top_window (void);
 
-extern void set_widgets_sensitivity (void);
-
 extern GtkWidget *server_filter_widget[];
 
 extern void print_status (GtkWidget *sbar, char *fmt, ...);
@@ -107,7 +106,8 @@ extern void set_toolbar_appearance (GtkToolbar *toolbar, int style, int tips);
 extern GtkWidget *create_progress_bar (void);
 extern void progress_bar_reset (GtkWidget *pbar);
 extern void progress_bar_start (GtkWidget *pbar, int activity_mode);
-extern void progress_bar_set_percentage (GtkWidget *pbar, float percentage);
+
+extern GtkWidget *filter_buttons[FILTERS_TOTAL];
 
 extern void ui_done (void);
 extern void restore_main_window_geometry (void);

--- a/src/xqf.h
+++ b/src/xqf.h
@@ -27,6 +27,9 @@
 #include <gtk/gtk.h>
 #include <glib.h>
 
+#include "defs.h"
+#include "game.h"
+
 #define RC_DIR          ".qf"               /* legacy config dir, before 1.0.6 */
 #define XDG_RC_DIR      "xqf"               /* new config dir, since 1.0.6 */
 #define RC_FILE         "qfrc"
@@ -41,215 +44,6 @@
 #define MAX_PING        9999
 #define MAX_RETRIES     10
 
-
-/* max 0x8000, server->flags is unsigned */
-enum server_flags {
-	PLAYER_GROUP_RED =      0x001,
-	PLAYER_GROUP_GREEN =    0x002,
-	PLAYER_GROUP_BLUE =     0x004,
-	PLAYER_GROUP_MASK =     0x007,
-
-	SERVER_CHEATS =         0x008,
-	SERVER_PASSWORD =       0x010,
-	SERVER_SP_PASSWORD =    0x020,
-	SERVER_SPECTATE =       0x040,
-	SERVER_PUNKBUSTER =     0x080,
-	SERVER_INCOMPATIBLE =   0x100
-};
-
-enum launch_mode {
-	LAUNCH_NORMAL,
-	LAUNCH_SPECTATE,
-	LAUNCH_RECORD
-};
-
-
-// note: there is a limit of 256 servers, see get_server_pixmap in srv-list.c
-enum server_type {
-	Q1_SERVER = 0,
-	QW_SERVER,
-	Q2_SERVER,
-	Q3_SERVER,
-	Q4_SERVER,
-	WO_SERVER,
-	WOET_SERVER,
-	ETL_SERVER,
-	DOOM3_SERVER,
-	ETQW_SERVER,
-	EF_SERVER,
-	H2_SERVER,
-	HW_SERVER,
-	SN_SERVER,
-	HL_SERVER_OLD,
-	HL_SERVER,
-	HL2_SERVER,
-	KP_SERVER,
-	SFS_SERVER,
-	SOF2S_SERVER,
-	T2_SERVER,
-	HR_SERVER,
-	UN_SERVER,
-	UT2_SERVER,
-	UT2004_SERVER,
-	RUNE_SERVER,
-	POSTAL2_SERVER,
-	AAO_SERVER,
-	DESCENT3_SERVER,
-	SSAM_SERVER,
-	SSAMSE_SERVER,
-	MOHAA_SERVER,
-	COD_SERVER,
-	SAS_SERVER,
-	BF1942_SERVER,
-	JK2_SERVER,
-	JK3_SERVER,
-	NETP_SERVER,
-	NEXUIZ_SERVER,
-	XONOTIC_SERVER,
-	WARSOW_SERVER,
-	TREMULOUS_SERVER,
-	TREMULOUSGPP_SERVER,
-	TREMFUSION_SERVER,
-	UNVANQUISHED_SERVER,
-	OPENARENA_SERVER,
-	OTTD_SERVER,
-	Q3RALLY_SERVER,
-	WOP_SERVER,
-	IOURT_SERVER,
-	REACTION_SERVER,
-	SMOKINGUNS_SERVER,
-	ZEQ2LITE_SERVER,
-	TURTLEARENA_SERVER,
-	ALIENARENA_SERVER,
-	GPS_SERVER,
-	UNKNOWN_SERVER
-};
-
-#define  GAMES_TOTAL UNKNOWN_SERVER
-
-enum master_state {
-	SOURCE_NA = 0,
-	SOURCE_UP,
-	SOURCE_DOWN,
-	SOURCE_TIMEOUT,
-	SOURCE_ERROR
-};
-
-enum master_query_type {
-	MASTER_NATIVE=0,
-	MASTER_GAMESPY,
-	MASTER_HTTP,
-	MASTER_LAN,
-	MASTER_FILE,
-	MASTER_GSLIST,
-	MASTER_NUM_QUERY_TYPES,
-	MASTER_INVALID_TYPE
-};
-
-
-/**
- * A player. There is no destructor for this struct. Alloc as many data as you
- * need at once and have the pointers point inside.
- */
-struct player {
-	char *name;
-	char *skin;
-	char *model;
-	int time;
-	short frags;
-	short ping;
-	unsigned char shirt;
-	unsigned char pants;
-	unsigned char flags;
-};
-
-struct host {
-	char *name;
-	struct in_addr ip;
-	time_t refreshed;
-	int ref_count;
-};
-
-
-/** server_new, server_free_info, server_move_info must be adapted for
- * changes to this structure
- */
-struct server {
-	struct host *host;
-
-	gchar *name;
-	char *map;
-	char **info;
-	char *game;         /** pointer into info, do not free */
-	char *gametype;     /** pointer into info, do not free */
-	GSList *players;    /** GSList<struct player *>  */
-
-#ifdef USE_GEOIP
-	int country_id;
-#endif
-
-	unsigned flags;
-
-	unsigned flt_last;  /** time of the last filtering */
-
-	time_t refreshed;
-	time_t last_answer; /** time of last reply from server */
-
-	int ref_count;
-
-	enum server_type type;
-	unsigned short port;
-
-	unsigned short maxplayers;
-	unsigned short curplayers;
-	unsigned short curbots;
-	unsigned short private_client;  /** number of private clients */
-	short ping;
-	short retries;
-
-	char sv_os;             /** L = Linux, W = windows, M = Mac */
-
-	unsigned char filters;
-	unsigned char flt_mask;
-};
-
-struct userver {
-	char *hostname;
-	struct server *s;
-	int ref_count;
-	unsigned short port;
-	unsigned char type;     /* enum server_type type; */
-};
-
-typedef struct {
-	int portadjust;         /* value added to port */
-	char* gsmtype;          /* type for gslist master */
-} QFMasterOptions;
-
-typedef struct master {
-	char *name;
-	enum server_type type;
-	int isgroup;            /* is it a real master or master group? */
-	int user;               /* is it added or edited by user? */
-	QFMasterOptions options;
-
-	struct host *host;
-	unsigned short port;
-	char *hostname;         /* unresolved hostname */
-
-	char *url;
-
-	GSList *servers;
-	GSList *uservers;
-	enum master_state state;
-
-	GSList *masters;
-
-	enum master_query_type master_type;
-
-	/** private */
-	char* _qstat_master_option; // optional override from games[type].qstat_master_option
-} QFMaster;
 
 char* master_qstat_option(struct master* m);
 void master_set_qstat_option(struct master* m, const char* opt);
@@ -271,6 +65,7 @@ extern struct server *cur_server;
 
 extern struct stat_job *stat_process;
 
+extern GtkBuilder *builder;
 
 int compare_qstat_version (const char* have, const char* expected);
 int start_prog_and_return_fd(char *const argv[], pid_t *pid);
@@ -278,8 +73,6 @@ int check_qstat_version(void);
 
 void play_sound (const char *sound, gboolean override);
 void play_sound_with (const char* player, const char *sound, gboolean override);
-
-extern void reset_main_status_bar(void);
 
 //extern int filter_start_index;
 


### PR DESCRIPTION
* Pilot attempt to move callbacks out of xqf.c. Refs #169
* Moved basic definitions to defs.h. It is now possible to include them without pulling xqf.h.
* GtkProgress calls ported to GtkProgressBar, existing GtkProgressBar calls made compliant with GTK2/3 specs.