### PR TITLE
more color flags, introduce xonotic color codes

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -31,19 +31,22 @@
 
 // game->flags
 enum {
-	GAME_CONNECT                = 0x0001,
-	GAME_RECORD                 = 0x0002,
-	GAME_SPECTATE               = 0x0004,
-	GAME_PASSWORD               = 0x0008,
-	GAME_RCON                   = 0x0010,
-	GAME_ADMIN                  = 0x0020,
-	GAME_QUAKE1_PLAYER_COLORS   = 0x0100,
-	GAME_QUAKE1_SKIN            = 0x0200,
-	GAME_QUAKE3_MASTERPROTOCOL  = 0x0400, // master server protocol version is in games_data["masterprotocol"]
-	GAME_LAUNCH_HOSTPORT        = 0x0800, // use hostport rule as port when launching
-	GAME_MASTER_CDKEY           = 0x1000, // master server requires CD key
-	GAME_Q3COLORS               = 0x2000, // Q3 color codes
-	GAME_MASTER_STEAM           = 0x4000, // server side filter
+	GAME_CONNECT                = 0x00001,
+	GAME_RECORD                 = 0x00002,
+	GAME_SPECTATE               = 0x00004,
+	GAME_PASSWORD               = 0x00008,
+	GAME_RCON                   = 0x00010,
+	GAME_ADMIN                  = 0x00020,
+	GAME_QUAKE1_PLAYER_COLORS   = 0x00100,
+	GAME_QUAKE1_SKIN            = 0x00200,
+	GAME_LAUNCH_HOSTPORT        = 0x00400, // use hostport rule as port when launching
+	GAME_MASTER_QUAKE3          = 0x01000, // master server protocol version is in games_data["masterprotocol"]
+	GAME_MASTER_CDKEY           = 0x02000, // master server requires CD key
+	GAME_MASTER_STEAM           = 0x04000, // server side filter
+	GAME_COLOR_QUAKE3           = 0x10000, // Quake 3 color codes
+	GAME_COLOR_SAVAGE           = 0x20000, // Savage color codes
+	GAME_COLOR_UNVANQUISHED     = 0x40000, // Unvanquished color codes
+	GAME_COLOR_XONOTIC          = 0x80000, // Xonotic color codes
 };
 
 struct game {

--- a/src/games.xml
+++ b/src/games.xml
@@ -590,7 +590,7 @@
 	</game>
 	<game>
 		<type>Q3_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_QUAKE3_MASTERPROTOCOL | GAME_Q3COLORS</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3</flags>
 		<name>Quake III Arena</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -695,7 +695,7 @@
 	<game>
 		<type>SAS_SERVER</type>
 		<name>Savage</name>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_ADMIN | GAME_Q3COLORS</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_ADMIN | GAME_COLOR_SAVAGE</flags>
 		<default_port>11235</default_port>
 		<id>SAS</id>
 		<qstat_str>SAS</qstat_str>
@@ -938,6 +938,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>UNVANQUISHED_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3 | GAME_COLOR_UNVANQUISHED | GAME_COLOR_XONOTIC</flags>
 		<name>Unvanquished</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -1049,6 +1050,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>XONOTIC_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3 | GAME_COLOR_XONOTIC</flags>
 		<name>Xonotic</name>
 		<default_port>26000</default_port>
 		<id>XONOTICS</id>

--- a/src/stat.c
+++ b/src/stat.c
@@ -1240,7 +1240,7 @@ static struct stat_conn *stat_update_master_qstat (struct stat_job *job, struct 
 			arg_type = g_strdup_printf("-gsm,%s,outfile", games[m->type].qstat_str);
 		}
 		// add master arguments
-		else if (games[m->type].flags & GAME_QUAKE3_MASTERPROTOCOL) {
+		else if (games[m->type].flags & GAME_MASTER_QUAKE3) {
 			// TODO: master protocol should be server specific
 			const char* masterprotocol = game_get_attribute(m->type,"masterprotocol");
 
@@ -1251,7 +1251,7 @@ static struct stat_conn *stat_update_master_qstat (struct stat_job *job, struct 
 				arg_type = g_strdup_printf("%s,%s,outfile", master_qstat_option(m),masterprotocol);
 			}
 			else {
-				xqf_warning("GAME_QUAKE3_MASTERPROTOCOL flag set, but no protocol specified");
+				xqf_warning("GAME_MASTER_QUAKE3 flag set, but no protocol specified");
 				arg_type = g_strdup_printf("%s,outfile", master_qstat_option(m));
 			}
 		}


### PR DESCRIPTION
- now use more than one flag to unescape color codes
  this way color escaping can be per-game configured
- also rewrite some flag names to unify the wording
- xonotic RGB color codes are now escaped

Hence, it's now possible to enable:
- GAME_COLOR_QUAKE3
- GAME_COLOR_SAVAGE
- GAME_COLOR_UNVANQUISHED
- GAME_COLOR_XONOTIC