### PR TITLE
Accurate Quake 3 color code removal

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -43,10 +43,12 @@ enum {
 	GAME_MASTER_QUAKE3          = 0x01000, // master server protocol version is in games_data["masterprotocol"]
 	GAME_MASTER_CDKEY           = 0x02000, // master server requires CD key
 	GAME_MASTER_STEAM           = 0x04000, // server side filter
-	GAME_COLOR_QUAKE3           = 0x10000, // Quake 3 color codes
-	GAME_COLOR_SAVAGE           = 0x20000, // Savage color codes
-	GAME_COLOR_UNVANQUISHED     = 0x40000, // Unvanquished color codes
-	GAME_COLOR_XONOTIC          = 0x80000, // Xonotic color codes
+	GAME_COLOR_QUAKE3_ANY       = 0x10000, // Quake 3 "^" followed by any character besides "^" color codes
+	GAME_COLOR_QUAKE3_NUMERIC   = 0x20000, // Quake 3 ^[0-9] color codes
+	GAME_COLOR_QUAKE3_ALPHA     = 0x40000, // ioquake3 ^[a-zA-Z] color codes
+	GAME_COLOR_UNVANQUISHED     = 0x80000, // Unvanquished color codes
+	GAME_COLOR_SAVAGE           = 0x100000, // Savage color codes
+	GAME_COLOR_XONOTIC          = 0x200000, // Xonotic color codes
 };
 
 struct game {

--- a/src/games.xml
+++ b/src/games.xml
@@ -338,6 +338,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>JK2_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
 		<name>Jedi Outcast</name>
 		<default_port>28070</default_port>
 		<default_master_port>28060</default_master_port>
@@ -356,6 +357,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>JK3_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
 		<name>Jedi Academy</name>
 		<default_port>29070</default_port>
 		<default_master_port>29060</default_master_port>
@@ -441,6 +443,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>OPENARENA_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>OpenArena</name>
 		<id>OPENARENAS</id>
 		<qstat_str>OPENARENAS</qstat_str>
@@ -487,6 +490,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>Q3RALLY_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>Q3 Rally</name>
 		<id>Q3RALLYS</id>
 		<qstat_str>Q3RALLYS</qstat_str>
@@ -561,7 +565,7 @@
 	</game>
 	<game>
 		<type>Q2_SERVER</type>
-		<flags>GAME_CONNECT | GAME_RECORD | GAME_SPECTATE | GAME_PASSWORD | GAME_RCON | GAME_COLOR_QUAKE3</flags>
+		<flags>GAME_CONNECT | GAME_RECORD | GAME_SPECTATE | GAME_PASSWORD | GAME_RCON | GAME_COLOR_QUAKE3_NUMERIC</flags>
 		<name>Quake2</name>
 		<default_port>27910</default_port>
 		<default_master_port>27900</default_master_port>
@@ -590,7 +594,7 @@
 	</game>
 	<game>
 		<type>Q3_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_ANY</flags>
 		<name>Quake III Arena</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -650,6 +654,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>REACTION_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>Reaction</name>
 		<id>REACTIONS</id>
 		<qstat_str>REACTIONS</qstat_str>
@@ -743,6 +748,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>SMOKINGUNS_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>Smokin' Guns</name>
 		<id>SMOKINGUNSS</id>
 		<qstat_str>SMOKINGUNSS</qstat_str>
@@ -811,6 +817,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMFUSION_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>TremFusion</name>
 		<default_port>30720</default_port>
 		<default_master_port>30710</default_master_port>
@@ -830,6 +837,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMULOUS_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>Tremulous</name>
 		<default_port>30720</default_port>
 		<default_master_port>30710</default_master_port>
@@ -850,6 +858,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMULOUSGPP_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>Tremulous GPP</name>
 		<default_port>30720</default_port>
 		<default_master_port>30700</default_master_port>
@@ -889,6 +898,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TURTLEARENA_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
 		<name>Turtle Arena</name>
 		<default_port>27960</default_port>
 		<id>TURTLEARENAS</id>
@@ -956,7 +966,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>UNVANQUISHED_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3 | GAME_COLOR_UNVANQUISHED | GAME_COLOR_XONOTIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_UNVANQUISHED | GAME_COLOR_XONOTIC</flags>
 		<name>Unvanquished</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -1051,6 +1061,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>WOP_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>World of Padman</name>
 		<id>WOPS</id>
 		<qstat_str>WOPS</qstat_str>
@@ -1068,7 +1079,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>XONOTIC_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3 | GAME_COLOR_XONOTIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_XONOTIC</flags>
 		<name>Xonotic</name>
 		<default_port>26000</default_port>
 		<id>XONOTICS</id>
@@ -1088,6 +1099,7 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>ZEQ2LITE_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
 		<name>ZEQ2 Lite</name>
 		<id>ZEQ2LITES</id>
 		<qstat_str>ZEQ2LITES</qstat_str>


### PR DESCRIPTION
Make Quake 3 remove all sequences of ^ followed by a character other than ^ to match the engine behavior. This is required for Wolfenstein: Enemy Territory servers as people use any character (such as ',').

Add a new color flag COLOR_QUAKE3_NUMERIC for games that expect only ^[0-9] to be removed such as Xonotic.

Add a new color flag COLOR_QUAKE3_ALPHA for ioquake3-based games that (combined with COLOR_QUAKE3_NUMERIC) expect only ^[0-9a-zA-Z].

----

While this is accurate for Quake 3 it is not accurate for all games based on it. This is kind of veering off into pointless and hard to maintain (accurate for all games) without per-game color removal function. [Some examples.](https://github.com/XQF/xqf/commit/6d46b4d84e517db96cb8f44e99815f4bbdb8b234#commitcomment-28227528) Jedi Outcast treats ^ followed by less or equal to '7' as a color (see ASCII table) whereas XQF will treat "^[0-9]" as colors. For Doom 3 "^^" should be removed instead of displayed as "^" by XQF.