### PR TITLE
 alternate game id in master server list / never trust qstat for game id

### DIFF
--- a/src/addmaster.c
+++ b/src/addmaster.c
@@ -100,7 +100,8 @@ static void master_okbutton_callback (GtkWidget *widget, GtkWidget* window) {
 		return;
 	}
 
-	master_to_add = add_master (master_addr_result, master_name_result, master_type, NULL, TRUE, FALSE);
+	// FIXME: gui does not allow to set server_query_type (defaults here as UNKNOWN_SERVER)
+	master_to_add = add_master (master_addr_result, master_name_result, master_type, UNKNOWN_SERVER, NULL, TRUE, FALSE);
 	if (!master_to_add) {
 		dialog_ok (NULL, _("Master address \"%s\" is not valid."),
 				master_addr_result);

--- a/src/defs.h
+++ b/src/defs.h
@@ -115,6 +115,7 @@ struct server {
 	int ref_count;
 
 	enum server_type type;
+	enum server_type server_query_type;
 	unsigned short port;
 
 	unsigned short maxplayers;
@@ -135,7 +136,8 @@ struct userver {
 	struct server *s;
 	int ref_count;
 	unsigned short port;
-	unsigned char type;     // enum server_type type;
+	enum server_type type;                  // enum server_type type;
+	enum server_type server_query_type;     // enum server_type type;
 };
 
 typedef struct {
@@ -146,6 +148,7 @@ typedef struct {
 typedef struct master {
 	char *name;
 	enum server_type type;
+	enum server_type server_query_type;
 	int isgroup;            // is it a real master or master group?
 	int user;               // is it added or edited by user?
 	QFMasterOptions options;

--- a/src/game.c
+++ b/src/game.c
@@ -116,7 +116,7 @@ static int ottd_exec (const struct condef *con, int forkit);
 
 static GList *quake_custom_cfgs (struct game* this, const char *path, const char *mod);
 
-static void quake_save_info (FILE *f, struct server *s);
+static void save_server_info (FILE *f, struct server *s);
 
 char **get_custom_arguments(enum server_type type, const char *gamestring);
 
@@ -3599,7 +3599,7 @@ static void quake_save_server_rules (FILE *f, struct server *s) {
 }
 
 
-static void quake_save_info (FILE *f, struct server *s) {
+static void save_server_info (FILE *f, struct server *s) {
 	struct player *p;
 	GSList *list;
 
@@ -3615,7 +3615,7 @@ static void quake_save_info (FILE *f, struct server *s) {
 		case Q1_SERVER:
 		case H2_SERVER:
 			fprintf (f,
-					"%s" QSTAT_DELIM_STR
+					"%s%s%s" QSTAT_DELIM_STR
 					"%s:%d" QSTAT_DELIM_STR
 					"%s" QSTAT_DELIM_STR
 					"%s:%d" QSTAT_DELIM_STR
@@ -3626,6 +3626,8 @@ static void quake_save_info (FILE *f, struct server *s) {
 					"%d" QSTAT_DELIM_STR
 					"%d\n",
 					games[s->type].id,
+					s->server_query_type != UNKNOWN_SERVER? "|" : "",
+					s->server_query_type != UNKNOWN_SERVER? games[s->server_query_type].id : "",
 					inet_ntoa (s->host->ip), s->port,
 					(s->name)? s->name : "",
 					inet_ntoa (s->host->ip), s->port,
@@ -3640,7 +3642,7 @@ static void quake_save_info (FILE *f, struct server *s) {
 
 		default:
 			fprintf (f,
-					"%s" QSTAT_DELIM_STR
+					"%s%s%s" QSTAT_DELIM_STR
 					"%s:%d" QSTAT_DELIM_STR
 					"%s" QSTAT_DELIM_STR
 					"%s" QSTAT_DELIM_STR
@@ -3649,6 +3651,8 @@ static void quake_save_info (FILE *f, struct server *s) {
 					"%d" QSTAT_DELIM_STR
 					"%d\n",
 					games[s->type].id,
+					s->server_query_type != UNKNOWN_SERVER? "|" : "",
+					s->server_query_type != UNKNOWN_SERVER? games[s->server_query_type].id : "",
 					inet_ntoa (s->host->ip), s->port,
 					(s->name)? s->name : "",
 					(s->map)? s->map : "",

--- a/src/games.xml
+++ b/src/games.xml
@@ -17,7 +17,7 @@
 		<write_config/>
 		<exec_client>exec_generic</exec_client>
 		<custom_cfgs/>
-		<save_info>quake_save_info</save_info>
+		<save_info>save_server_info</save_info>
 		<init_maps/>
 		<has_map/>
 		<get_mapshot/>

--- a/src/masters.c
+++ b/src/masters.c
@@ -22,6 +22,24 @@ static char *builtin_masters_update_info[] = {
 	 *
 	 */
 
+	// uses http list instead, replaced 2018-03-24
+	"DELETE AMS,-gsm,armygame gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE BF1942,-gsm,bfield1942 gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE MHS,-gsm,mohaa gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE Q2S:KP,-gsm,kingpin gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE RUNESRV,-gsm,rune gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE SMS,-gsm,serioussam gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE SMSSE,-gsm,serioussamse gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE UNS,-gsm,ut gmaster://gsm.qtracker.com:28900 qtracker.com (ut99)",
+	"DELETE UNS,-gsm,unreal gmaster://gsm.qtracker.com:28900 qtracker.com (unreal)",
+	"DELETE UT2004S,-gsm,ut2004 gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE UT2S,-gsm,ut2 gmaster://gsm.qtracker.com:28900 qtracker.com",
+	"DELETE SNS,-gsm,sin gmaster://gsm.qtracker.com:28900 qtracker.com",
+
+	// does no longer work, removed 2018-03-24
+	"DELETE Q2S master://netdome.biz:27900 netdome.biz",
+	"DELETE Q2S master://masterserver.exhale.de:27900 exhale.de", // down since 2011
+
 	// does no longer work, removed 2018-03-21
 	"DELETE UNS,-gsm,ut gmaster://master.noccer.de:28900 noccer.de",
 
@@ -160,6 +178,22 @@ static char *builtin_masters_update_info[] = {
 
 	// added 2018-03-24
 	"ADD DDAYS http://q2servers.com/?g=dday&raw=1 q2servers.com",
+	"ADD MHS,-gsm,mohaa gmaster://master.x-null.net:28900 x-null.net",
+	"ADD Q2S master://master.rlogin.dk:27900 rlogin.dk",
+	"ADD Q2S http://q2servers.com/?raw=1 q2servers.com",
+	"ADD Q3S master://master.huxxer.de:27950 huxxer.de",
+	"ADD AMS|GPS http://www.qtracker.com/server_list_details.php?game=armyoperations qtracker.com",
+	"ADD BF1942|GPS http://www.qtracker.com/server_list_details.php?game=battlefield1942 qtracker.com",
+	"ADD MHS|GPS http://www.qtracker.com/server_list_details.php?game=medalofhonoralliedassault qtracker.com",
+	"ADD Q2S:KP|GPS http://www.qtracker.com/server_list_details.php?game=kingpin qtracker.com",
+	"ADD RUNESRV|GPS http://www.qtracker.com/server_list_details.php?game=rune qtracker.com",
+	"ADD SMS|GPS http://www.qtracker.com/server_list_details.php?game=serioussam qtracker.com",
+	"ADD SMSSE|GPS http://www.qtracker.com/server_list_details.php?game=serioussamse qtracker.com",
+	"ADD UNS|GPS http://www.qtracker.com/server_list_details.php?game=unrealtournament qtracker.com (ut99)",
+	"ADD UNS|GPS http://www.qtracker.com/server_list_details.php?game=unreal qtracker.com (unreal)",
+	"ADD UT2004S|GPS http://www.qtracker.com/server_list_details.php?game=unrealtournament2004 qtracker.com",
+	"ADD UT2S|GPS http://www.qtracker.com/server_list_details.php?game=unrealtournament2003 qtracker.com",
+	"ADD SNS|GPS http://www.qtracker.com/server_list_details.php?game=sin qtracker.com",
 
 	// added 2018-03-21
 	"ADD UNS,-gsm,unreal gmaster://master.hlkclan.net:28900 master.hlkclan.net (unreal)",
@@ -193,20 +227,6 @@ static char *builtin_masters_update_info[] = {
 	"ADD RUNESRV,-gsm,rune gmaster://master.333networks.com:28900 333networks.com",
 	"ADD UNS,-gsm,ut gmaster://master.333networks.com:28900 333networks.com",
 	"ADD UNS,-gsm,ut gmaster://master.errorist.tk:28900 errorist.tk",
-
-	// added 2015-08-20
-	"ADD AMS,-gsm,armygame gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD BF1942,-gsm,bfield1942 gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD MHS,-gsm,mohaa gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD Q2S:KP,-gsm,kingpin gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD RUNESRV,-gsm,rune gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD SMS,-gsm,serioussam gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD SMSSE,-gsm,serioussamse gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD UNS,-gsm,ut gmaster://gsm.qtracker.com:28900 qtracker.com (ut99)",
-	"ADD UNS,-gsm,unreal gmaster://gsm.qtracker.com:28900 qtracker.com (unreal)",
-	"ADD UT2004S,-gsm,ut2004 gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD UT2S,-gsm,ut2 gmaster://gsm.qtracker.com:28900 qtracker.com",
-	"ADD SNS,-gsm,sin gmaster://gsm.qtracker.com:28900 qtracker.com",
 
 	// added 2015-08-19
 	"ADD ETLS master://master.etlegacy.com:27950 etlegacy.com",
@@ -352,9 +372,6 @@ static char *builtin_masters_update_info[] = {
 	// added 2004-10-14
 	"ADD D3G http://d3.descent.cx/d3cxraw.d3?terse=y descent.cx",
 
-	// added 2004-09-26
-	"ADD Q2S master://netdome.biz netdome.biz",
-
 	// added 2004-08-07
 	"ADD DM3S master://idnet.ua-corp.com:27650 ua-corp.com",
 
@@ -425,6 +442,7 @@ static char *builtin_masters_update_info[] = {
 	"ADD RUNESRV lan://255.255.255.255 LAN",
 	"ADD SFS lan://255.255.255.255 LAN",
 	"ADD SMOKINGUNSS lan://255.255.255.255 LAN",
+	"ADD TEES lan://255.255.255.255 LAN",
 	"ADD T2S lan://255.255.255.255 LAN",
 	"ADD TREMFUSIONS lan://255.255.255.255 LAN",
 	"ADD TREMULOUSGPPS lan://255.255.255.255 LAN",

--- a/src/server.c
+++ b/src/server.c
@@ -95,6 +95,7 @@ static struct server *server_new (struct host *h, unsigned short port,
 	server->type = type;
 	server->ping = -1;
 	server->retries = -1;
+	server->server_query_type = UNKNOWN_SERVER;
 
 #ifdef USE_GEOIP
 	server->country_id = geoip_id_by_ip(h->ip);
@@ -116,6 +117,7 @@ static struct userver *userver_new (const char *hostname, unsigned short port,
 	userver->hostname = g_strdup (hostname);
 	userver->port = port;
 	userver->type = type;
+	userver->server_query_type = UNKNOWN_SERVER;
 
 	return userver;
 }
@@ -473,6 +475,7 @@ struct server *userver_set_host (struct userver *us, struct host *h) {
 	server = server_add (h, us->port, us->type);
 	if (server) {
 		us->s = server;
+		us->s->server_query_type = us->server_query_type;
 	}
 
 	return server;

--- a/src/source.h
+++ b/src/source.h
@@ -26,10 +26,6 @@
 #define FILENAME_LISTS      "lists"
 #define FILENAME_SRVINFO    "srvinfo"
 
-// #define PREFIX_MASTER       "master://"
-// #define PREFIX_GMASTER      "gmaster://"
-// #define PREFIX_URL_HTTP     "http://"
-
 #define ACTION_ADD          "ADD"
 #define ACTION_DELETE       "DELETE"
 
@@ -42,6 +38,7 @@ extern GSList *master_groups;
 extern struct master *add_master (char *path,
 		char *name,
 		enum server_type type,
+		enum server_type server_query_type,
 		const char* qstat_query_arg,
 		int user,
 		int lookup_only);

--- a/src/stat.c
+++ b/src/stat.c
@@ -170,7 +170,15 @@ static int parse_master_output (char *str, struct stat_conn *conn) {
 		if (n <= 3) {
 			return TRUE;
 		}
-		type = id2type (token[0]);
+
+		// never do that: qstat returns the qstat_str, not the game id
+		// for example we use -cods for COD:UO that will return CODS
+		// instead of CODUOS and XQF will mark the server for the
+		// wrong game, never trust qstat, always trust XQF
+		// type = id2type (token[0]);
+
+		type = conn->master->type;
+
 		n = 2; // we only need type and ip
 	}
 	else if (n >= 3) {
@@ -221,7 +229,13 @@ static int parse_master_output (char *str, struct stat_conn *conn) {
 			// <type>\0<hostname>:<port>
 			// expected to be found in qstat output
 			case 2:
-				type = id2type (token[0]);
+				// never do that: qstat returns the qstat_str, not the game id
+				// for example we use -cods for COD:UO that will return CODS
+				// instead of CODUOS and XQF will mark the server for the
+				// wrong game, never trust qstat, always trust XQF
+				// type = id2type (token[0]);
+
+				type = conn->master->type;
 				break;
 
 			// this is not expected at all
@@ -352,6 +366,7 @@ static gboolean stat_master_input_callback (GIOChannel *chan, GIOCondition condi
 			} else {
 				stat_master_update_done (conn, job, conn->master, SOURCE_UP);
 			}
+
 			stat_update_masters (job);
 			debug_decrease_indent();
 			g_free(buf);
@@ -1490,7 +1505,6 @@ static struct stat_conn *stat_open_conn_qstat (struct stat_job *job) {
 	argv[argi++] = "-P";
 
 	argv[argi++] = "-carets";
-
 
 	if (g_slist_length (job->servers) <= MAX_SERVERS_IN_CMDLINE) {
 		for (tmp = job->servers; tmp; tmp = tmp->next) {


### PR DESCRIPTION
## allow to set an alternate game id in master server list

some games are known to support multiple protocols, when you fetch a web list of server, it's good to be able to enforce which alternative protocol must be used to query the servers from this specific list

this functionality is currently only supported in hard coded list of masters, the GUI does not allow to set the alternative query protocol when adding a master server by hand or a server by hand, by the way user config files can be edited to reflect that.

you can set an alternate this way (using a pipe as separator):

```
ADD AMS|GPS http://www.qtracker.com/server_list_details.php?game=armyoperations qtracker.com
```

server fetched by this master server will be queried using the gamespy GPS protocol instead of the AMS one, but they will be considered as AMS games.

it prevents some games to answer strings like:

> what broken query tool do you use?

because basically some version grok an old protocol but other versions only grok the gamespy one: if the server is listed in a gamespy master server, always query it using the gamespy server protocol

## never trust qstat for game id

qstat returns the qstat_str, not the game id for example we use `-cods` for COD:UO that will return `CODS` instead of `CODUOS` and XQF will mark the server for the wrong game, never trust qstat, always trust XQF.

it also avoids the need to create useless entries in `qstat.cfg` just to tell XQF to query the right game relying on qstat output: never rely on it, XQF knows what is good.

## update master server list

update master server list to use these features