### PR TITLE
more color code filtering

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -105,7 +105,7 @@ struct server {
 	int country_id;
 #endif
 
-	unsigned flags;
+	unsigned long flags;
 
 	unsigned flt_last;  // time of the last filtering
 

--- a/src/game.c
+++ b/src/game.c
@@ -436,9 +436,14 @@ static void unescape_game_string (char *dst, const char *src, unsigned long flag
 						}
 					}
 				}
-				if (has_flag(flags, COLOR_UNVANQUISHED)) {
+				if (has_flag(flags, COLOR_WOLFET)) {
+					// see https://github.com/etlegacy/etlegacy/blob/master/src/qcommon/q_math.h
+					// Wolf:ET also supports ^[0-9] but that's already handled by the Quake 3 numeric color filter
+					// Wolf:ET also supports ^* so that flag is to be used by games that
+					// inherit Wolf:ET color codes without having support for COLOR_QUAKE3_ANY
+					// like Unvanquished that inherits these color codes from Wolf:ET through ET:XreaL
+					// but does not filter out unknown codes
 					// see https://github.com/DaemonEngine/Daemon/blob/master/src/common/Color.cpp
-					// Unvanquished also supports ^[0-9] but that's already handled by the Quake 3 numeric color filter
 					if ((src[isrc + 1] >= 'A' && src[isrc + 1] <= 'O')
 						|| (src[isrc + 1] >= 'a' && src[isrc + 1] <= 'o')
 						|| src[isrc + 1] == ':'

--- a/src/game.c
+++ b/src/game.c
@@ -356,15 +356,7 @@ static gboolean has_flag(unsigned long flags, unsigned long flag) {
 }
 
 static gboolean is_game_string_unescapable(unsigned long flags) {
-	return has_flag(flags, 0
-		| COLOR_QUAKE3_ALPHA
-		| COLOR_QUAKE3_ANY
-		| COLOR_QUAKE3_NUMERIC
-		| COLOR_QUAKE4
-		| COLOR_SAVAGE
-		| COLOR_UNVANQUISHED
-		| COLOR_XONOTIC
-	);
+	return flags != 0;
 }
 
 /*
@@ -385,8 +377,14 @@ static void unescape_game_string (char *dst, const char *src, unsigned long flag
 			if (src[isrc + 1] != '\0') {
 				// if "^^"
 				if (src[isrc + 1] == '^') {
-					// only skip one '^', display only one '^'
-					step = 1;
+					if (has_flag(flags, COLOR_DOOM3)) {
+						// skip the two '^' since Doom 3's ^^ is empty string
+						step = 2;
+					}
+					else {
+						// only skip one '^', display only one '^'
+						step = 1;
+					}
 					goto walk;
 				}
 				if (has_flag(flags, COLOR_QUAKE3_NUMERIC)) {

--- a/src/game.c
+++ b/src/game.c
@@ -355,20 +355,18 @@ static gboolean has_flag(unsigned long flags, unsigned long flag) {
 	return (flags & flag) != 0;
 }
 
-static gboolean is_game_string_unescapable(enum server_type type) {
-	return !has_flag(games[type].flags, GAME_COLOR_QUAKE3_ANY | GAME_COLOR_QUAKE3_NUMERIC
-		| GAME_COLOR_QUAKE3_ALPHA | GAME_COLOR_SAVAGE | GAME_COLOR_UNVANQUISHED | GAME_COLOR_XONOTIC);
+static gboolean is_game_string_unescapable(unsigned long flags) {
+	return has_flag(flags, COLOR_QUAKE3_ANY | COLOR_QUAKE3_NUMERIC
+		| COLOR_QUAKE3_ALPHA | COLOR_SAVAGE | COLOR_UNVANQUISHED | COLOR_XONOTIC);
 }
 
 /*
  * you MUST allocate dst with g_malloc0 before, this function and others assumes that dst is filled with zeros
  */
-static void unescape_game_string (char *dst, const char *src, enum server_type type) {
+static void unescape_game_string (char *dst, const char *src, unsigned long flags) {
 	/*
 	 * skip color codes
 	 */
-
-	unsigned long flags = games[type].flags;
 
 	gint idst = 0;
 	gint isrc = 0;
@@ -384,7 +382,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 					step = 1;
 					goto walk;
 				}
-				if (has_flag(flags, GAME_COLOR_QUAKE3_NUMERIC)) {
+				if (has_flag(flags, COLOR_QUAKE3_NUMERIC)) {
 					if (src[isrc + 1] >= '0' && src[isrc + 1] <= '9') {
 						// one-char color code in the form ^# where # is a numeric digit
 						// skip '^' and the next char
@@ -392,7 +390,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 						goto walk;
 					}
 				}
-				if (has_flag(flags, GAME_COLOR_QUAKE3_ALPHA)) {
+				if (has_flag(flags, COLOR_QUAKE3_ALPHA)) {
 					if ((src[isrc + 1] >= 'A' && src[isrc + 1] <= 'Z')
 						|| (src[isrc + 1] >= 'a' && src[isrc + 1] <= 'z')) {
 						// one-char color code in the form ^# where # is a case-insentive
@@ -402,7 +400,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 						goto walk;
 					}
 				}
-				if (has_flag(flags, GAME_COLOR_UNVANQUISHED)) {
+				if (has_flag(flags, COLOR_UNVANQUISHED)) {
 					// see https://github.com/DaemonEngine/Daemon/blob/master/src/common/Color.cpp
 					// Unvanquished also supports ^[0-9] but that's already handled by the Quake 3 numeric color filter
 					if ((src[isrc + 1] >= 'A' && src[isrc + 1] <= 'O')
@@ -422,7 +420,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 						goto walk;
 					}
 				}
-				if (has_flag(flags, GAME_COLOR_XONOTIC)) {
+				if (has_flag(flags, COLOR_XONOTIC)) {
 					// see https://xonotic.org/faq/#how-can-i-use-colors-in-my-nickname-and-messages
 					// RGB color codes in the form ^x### where # is a case-insensitive hexadecimal digit
 					// Xonotic also supports ^[0-9] but that's already handled by the Quake 3 numeric color filter
@@ -442,7 +440,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 						}
 					}
 				}
-				if (has_flag(flags, GAME_COLOR_SAVAGE)) {
+				if (has_flag(flags, COLOR_SAVAGE)) {
 					// if Savage three chars color code in the form ^### where # is a numeric digit
 					gint i;
 					for (i = 1; (src[isrc + i] != '\0'
@@ -485,7 +483,7 @@ static void unescape_game_string (char *dst, const char *src, enum server_type t
 						}
 					}
 				}
-				if (has_flag(flags, GAME_COLOR_QUAKE3_ANY)) {
+				if (has_flag(flags, COLOR_QUAKE3_ANY)) {
 					// one-char color code in the form ^# where # is any character
 					// skip '^' and the next char
 					step = 2;
@@ -676,7 +674,8 @@ static struct player *q3_parse_player (char *token[], int n, struct server *s) {
 	if (player->ping == 0) ++s->curbots;
 
 	player->name = (char *) player + sizeof (struct player);
-	unescape_game_string (player->name, token[0], s->type);
+	// overwrite in place
+	unescape_game_string (player->name, token[0], games[s->type].color_flags);
 
 	// show clan name in model column
 	if (clan) {
@@ -685,7 +684,7 @@ static struct player *q3_parse_player (char *token[], int n, struct server *s) {
 		}
 		else {
 			player->model = (char *) player + sizeof (struct player) + strlen(player->name) + 1;
-			unescape_game_string(player->model, clan, s->type);
+			unescape_game_string(player->model, clan, games[s->type].color_flags);
 		}
 	}
 
@@ -776,13 +775,13 @@ static void quake_parse_server (char *token[], int n, struct server *server) {
 		return;
 
 	if (*(token[2])) {      /* if name is not empty */
-		if (is_game_string_unescapable(server->type)) {
+		if (!is_game_string_unescapable(games[server->type].flags)) {
 			server->name = g_strdup (token[2]);
 		}
 		else {
 			server->name = g_malloc0 (sizeof (char) * strlen (token[2]) + 1);
 			debug(6, "maxsize:%d", (int) (sizeof (char) * strlen (token[2]) + 1));
-			unescape_game_string (server->name, token[2], server->type);
+			unescape_game_string (server->name, token[2], games[server->type].color_flags);
 		}
 	}
 
@@ -1970,7 +1969,7 @@ static void q3_analyze_serverinfo (struct server *s) {
 			if (s->gametype) {
 				// unescape in place, for backward compatibility
 				gchar* tmp_gametype = g_malloc0 (sizeof (gchar) * strlen (s->gametype) + 1);
-				unescape_game_string(tmp_gametype, s->gametype, s->type);
+				unescape_game_string(tmp_gametype, s->gametype, games[s->type].color_flags);
 				strcpy(s->gametype, tmp_gametype);
 				g_free(tmp_gametype);
 			}
@@ -2126,15 +2125,13 @@ static void doom3_analyze_serverinfo (struct server *s) {
 	/* Clear out the flags */
 	s->flags = 0;
 
-	if ((games[s->type].flags & GAME_SPECTATE) != 0)
+	if ((games[s->type].flags & GAME_SPECTATE) != 0) {
 		s->flags |= SERVER_SPECTATE;
-
+	}
 	for (info_ptr = s->info; info_ptr && *info_ptr; info_ptr += 2) {
-
 		if (strcmp (*info_ptr, "fs_game") == 0) {
 			fs_game  = info_ptr[1];
 		}
-
 		else if (strcmp (*info_ptr, "si_version") == 0) {
 			if (strstr (info_ptr[1], "linux")) {
 				s->sv_os = 'L';
@@ -2146,7 +2143,6 @@ static void doom3_analyze_serverinfo (struct server *s) {
 				s->sv_os = '?';
 			}
 		}
-
 		else if (!s->gametype && strcmp (*info_ptr, "si_gameType") == 0) {
 			s->gametype = info_ptr[1];
 		}

--- a/src/game.h
+++ b/src/game.h
@@ -47,12 +47,13 @@ enum {
 
 // game->color_flags
 enum {
-	COLOR_QUAKE3_ANY            = 0x00001, // Quake 3 "^" followed by any character besides "^" color codes
-	COLOR_QUAKE3_NUMERIC        = 0x00002, // Quake 3 ^[0-9] color codes
-	COLOR_QUAKE3_ALPHA          = 0x00004, // ioquake3 ^[a-zA-Z] color codes
-	COLOR_UNVANQUISHED          = 0x00008, // Unvanquished color codes
+	COLOR_QUAKE3_ALPHA          = 0x00001, // ioquake3 ^[a-zA-Z] color codes
+	COLOR_QUAKE3_ANY            = 0x00002, // Quake 3 "^" followed by any character besides "^" color codes
+	COLOR_QUAKE3_NUMERIC        = 0x00004, // Quake 3 ^[0-9] color codes
+	COLOR_QUAKE4                = 0x00008, // Quake 4 color codes
 	COLOR_SAVAGE                = 0x00010, // Savage color codes
-	COLOR_XONOTIC               = 0x00020, // Xonotic color codes
+	COLOR_UNVANQUISHED          = 0x00020, // Unvanquished color codes
+	COLOR_XONOTIC               = 0x00040, // Xonotic color codes
 };
 
 struct game {

--- a/src/game.h
+++ b/src/game.h
@@ -47,13 +47,14 @@ enum {
 
 // game->color_flags
 enum {
-	COLOR_QUAKE3_ALPHA          = 0x00001, // ioquake3 ^[a-zA-Z] color codes
-	COLOR_QUAKE3_ANY            = 0x00002, // Quake 3 "^" followed by any character besides "^" color codes
-	COLOR_QUAKE3_NUMERIC        = 0x00004, // Quake 3 ^[0-9] color codes
-	COLOR_QUAKE4                = 0x00008, // Quake 4 color codes
-	COLOR_SAVAGE                = 0x00010, // Savage color codes
-	COLOR_UNVANQUISHED          = 0x00020, // Unvanquished color codes
-	COLOR_XONOTIC               = 0x00040, // Xonotic color codes
+	COLOR_DOOM3                 = 0x00001, // Doom 3 ^^ is empty string
+	COLOR_QUAKE3_ALPHA          = 0x00002, // ioquake3 ^[a-zA-Z] color codes
+	COLOR_QUAKE3_ANY            = 0x00004, // Quake 3 ^ followed by any character besides ^ color codes
+	COLOR_QUAKE3_NUMERIC        = 0x00008, // Quake 3 ^[0-9] color codes
+	COLOR_QUAKE4                = 0x00010, // Quake 4 color codes
+	COLOR_SAVAGE                = 0x00020, // Savage color codes
+	COLOR_UNVANQUISHED          = 0x00040, // Unvanquished color codes
+	COLOR_XONOTIC               = 0x00080, // Xonotic color codes
 };
 
 struct game {

--- a/src/game.h
+++ b/src/game.h
@@ -43,17 +43,22 @@ enum {
 	GAME_MASTER_QUAKE3          = 0x01000, // master server protocol version is in games_data["masterprotocol"]
 	GAME_MASTER_CDKEY           = 0x02000, // master server requires CD key
 	GAME_MASTER_STEAM           = 0x04000, // server side filter
-	GAME_COLOR_QUAKE3_ANY       = 0x10000, // Quake 3 "^" followed by any character besides "^" color codes
-	GAME_COLOR_QUAKE3_NUMERIC   = 0x20000, // Quake 3 ^[0-9] color codes
-	GAME_COLOR_QUAKE3_ALPHA     = 0x40000, // ioquake3 ^[a-zA-Z] color codes
-	GAME_COLOR_UNVANQUISHED     = 0x80000, // Unvanquished color codes
-	GAME_COLOR_SAVAGE           = 0x100000, // Savage color codes
-	GAME_COLOR_XONOTIC          = 0x200000, // Xonotic color codes
+};
+
+// game->color_flags
+enum {
+	COLOR_QUAKE3_ANY            = 0x00001, // Quake 3 "^" followed by any character besides "^" color codes
+	COLOR_QUAKE3_NUMERIC        = 0x00002, // Quake 3 ^[0-9] color codes
+	COLOR_QUAKE3_ALPHA          = 0x00004, // ioquake3 ^[a-zA-Z] color codes
+	COLOR_UNVANQUISHED          = 0x00008, // Unvanquished color codes
+	COLOR_SAVAGE                = 0x00010, // Savage color codes
+	COLOR_XONOTIC               = 0x00020, // Xonotic color codes
 };
 
 struct game {
 	enum server_type type;
 	unsigned long flags;
+	unsigned long color_flags;
 
 	char *name;
 	unsigned short default_port;

--- a/src/game.h
+++ b/src/game.h
@@ -53,7 +53,7 @@ enum {
 	COLOR_QUAKE3_NUMERIC        = 0x00008, // Quake 3 ^[0-9] color codes
 	COLOR_QUAKE4                = 0x00010, // Quake 4 color codes
 	COLOR_SAVAGE                = 0x00020, // Savage color codes
-	COLOR_UNVANQUISHED          = 0x00040, // Unvanquished color codes
+	COLOR_WOLFET                = 0x00040, // Wolfenstein: Enemy Territory color codes
 	COLOR_XONOTIC               = 0x00080, // Xonotic color codes
 };
 

--- a/src/games.xml
+++ b/src/games.xml
@@ -184,6 +184,7 @@
 		<base>Q3_SERVER</base>
 		<type>DOOM3_SERVER</type>
 		<name>Doom 3</name>
+		<color_flags>COLOR_DOOM3 | COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<default_port>27666</default_port>
 		<default_master_port>27650</default_master_port>
 		<id>DM3S</id>
@@ -645,7 +646,7 @@
 		<base>Q3_SERVER</base>
 		<type>Q4_SERVER</type>
 		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
-		<color_flags>COLOR_QUAKE3_ANY | COLOR_QUAKE4</color_flags>
+		<color_flags>COLOR_DOOM3 | COLOR_QUAKE3_ANY | COLOR_QUAKE4</color_flags>
 		<name>Quake 4</name>
 		<default_port>28004</default_port>
 		<default_master_port>27650</default_master_port>

--- a/src/games.xml
+++ b/src/games.xml
@@ -1008,7 +1008,7 @@
 		<base>Q3_SERVER</base>
 		<type>UNVANQUISHED_SERVER</type>
 		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
-		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_UNVANQUISHED | COLOR_XONOTIC</color_flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_WOLFET | COLOR_XONOTIC</color_flags>
 		<name>Unvanquished</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>

--- a/src/games.xml
+++ b/src/games.xml
@@ -2,6 +2,7 @@
 	<game>
 		<type>DEFAULT</type>
 		<flags/>
+		<color_flags/>
 		<name/>
 		<default_port/>
 		<default_master_port/>
@@ -348,7 +349,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>JK2_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
 		<name>Jedi Outcast</name>
 		<default_port>28070</default_port>
 		<default_master_port>28060</default_master_port>
@@ -367,7 +369,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>JK3_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
 		<name>Jedi Academy</name>
 		<default_port>29070</default_port>
 		<default_master_port>29060</default_master_port>
@@ -453,7 +456,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>OPENARENA_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>OpenArena</name>
 		<id>OPENARENAS</id>
 		<qstat_str>OPENARENAS</qstat_str>
@@ -500,7 +504,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>Q3RALLY_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>Q3 Rally</name>
 		<id>Q3RALLYS</id>
 		<qstat_str>Q3RALLYS</qstat_str>
@@ -575,7 +580,8 @@
 	</game>
 	<game>
 		<type>Q2_SERVER</type>
-		<flags>GAME_CONNECT | GAME_RECORD | GAME_SPECTATE | GAME_PASSWORD | GAME_RCON | GAME_COLOR_QUAKE3_NUMERIC</flags>
+		<flags>GAME_CONNECT | GAME_RECORD | GAME_SPECTATE | GAME_PASSWORD | GAME_RCON</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
 		<name>Quake2</name>
 		<default_port>27910</default_port>
 		<default_master_port>27900</default_master_port>
@@ -604,7 +610,8 @@
 	</game>
 	<game>
 		<type>Q3_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_ANY</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_ANY</color_flags>
 		<name>Quake III Arena</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -637,6 +644,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>Q4_SERVER</type>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
 		<name>Quake 4</name>
 		<default_port>28004</default_port>
 		<default_master_port>27650</default_master_port>
@@ -680,7 +689,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>REACTION_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>Reaction</name>
 		<id>REACTIONS</id>
 		<qstat_str>REACTIONS</qstat_str>
@@ -726,7 +736,8 @@
 	<game>
 		<type>SAS_SERVER</type>
 		<name>Savage</name>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_ADMIN | GAME_COLOR_SAVAGE</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_ADMIN</flags>
+		<color_flags>COLOR_SAVAGE</color_flags>
 		<default_port>11235</default_port>
 		<id>SAS</id>
 		<qstat_str>SAS</qstat_str>
@@ -774,7 +785,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>SMOKINGUNS_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>Smokin' Guns</name>
 		<id>SMOKINGUNSS</id>
 		<qstat_str>SMOKINGUNSS</qstat_str>
@@ -841,7 +853,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMFUSION_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>TremFusion</name>
 		<default_port>30720</default_port>
 		<default_master_port>30710</default_master_port>
@@ -861,7 +874,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMULOUS_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>Tremulous</name>
 		<default_port>30720</default_port>
 		<default_master_port>30710</default_master_port>
@@ -882,7 +896,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TREMULOUSGPP_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>Tremulous GPP</name>
 		<default_port>30720</default_port>
 		<default_master_port>30700</default_master_port>
@@ -922,7 +937,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>TURTLEARENA_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
 		<name>Turtle Arena</name>
 		<default_port>27960</default_port>
 		<id>TURTLEARENAS</id>
@@ -990,7 +1006,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>UNVANQUISHED_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_UNVANQUISHED | GAME_COLOR_XONOTIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_UNVANQUISHED | COLOR_XONOTIC</color_flags>
 		<name>Unvanquished</name>
 		<default_port>27960</default_port>
 		<default_master_port>27950</default_master_port>
@@ -1085,7 +1102,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>WOP_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>World of Padman</name>
 		<id>WOPS</id>
 		<qstat_str>WOPS</qstat_str>
@@ -1103,7 +1121,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>XONOTIC_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_XONOTIC</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_XONOTIC</color_flags>
 		<name>Xonotic</name>
 		<default_port>26000</default_port>
 		<id>XONOTICS</id>
@@ -1123,7 +1142,8 @@
 	<game>
 		<base>Q3_SERVER</base>
 		<type>ZEQ2LITE_SERVER</type>
-		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3 | GAME_COLOR_QUAKE3_NUMERIC | GAME_COLOR_QUAKE3_ALPHA</flags>
+		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
+		<color_flags>COLOR_QUAKE3_NUMERIC | COLOR_QUAKE3_ALPHA</color_flags>
 		<name>ZEQ2 Lite</name>
 		<id>ZEQ2LITES</id>
 		<qstat_str>ZEQ2LITES</qstat_str>

--- a/src/games.xml
+++ b/src/games.xml
@@ -645,7 +645,7 @@
 		<base>Q3_SERVER</base>
 		<type>Q4_SERVER</type>
 		<flags>GAME_CONNECT | GAME_PASSWORD | GAME_RCON | GAME_MASTER_QUAKE3</flags>
-		<color_flags>COLOR_QUAKE3_NUMERIC</color_flags>
+		<color_flags>COLOR_QUAKE3_ANY | COLOR_QUAKE4</color_flags>
 		<name>Quake 4</name>
 		<default_port>28004</default_port>
 		<default_master_port>27650</default_master_port>

--- a/src/gamesxml2c.c
+++ b/src/gamesxml2c.c
@@ -30,6 +30,7 @@ typedef enum
 	TAG_start_basic = Tag_0,
 	TAG_type = TAG_start_basic,
 	TAG_flags,
+	TAG_color_flags,
 	TAG_name,
 	TAG_default_port,
 	TAG_default_master_port,
@@ -104,6 +105,7 @@ static void add_tag(GameTag nr, TagInherit inherit, TagType type, const xmlChar*
 static void tags_init() {
 	add_tag(TAG_type,                   Tag_no_inherit, Tag_type_literal, (xmlChar*) "type");
 	add_tag(TAG_flags,                  Tag_do_inherit, Tag_type_literal, (xmlChar*) "flags");
+	add_tag(TAG_color_flags,            Tag_do_inherit, Tag_type_literal, (xmlChar*) "color_flags");
 	add_tag(TAG_name,                   Tag_no_inherit, Tag_type_string,  (xmlChar*) "name");
 	add_tag(TAG_default_port,           Tag_do_inherit, Tag_type_literal, (xmlChar*) "default_port");
 	add_tag(TAG_default_master_port,    Tag_do_inherit, Tag_type_literal, (xmlChar*) "default_master_port");


### PR DESCRIPTION
I noticed some Q4 servers used `^c###` with `#` in `[0-9]` for color codes, see:
http://ewz-quake3forums.forumsmotion.com/t28-quake-4-color-code-chart

I only see them on q4max modded servers, I don't know if it's mod specific or not, and by the way the code is not ready to filter color codes by mod.

I noticed the same q4max servers also used `^-` and `^+` color codes, well the behaviour looks to not be color, perhaps it's a font thing, but they looks to have to be filtered.

I noticed some q4 players using the icons code in their name as described there:
https://www.gamespot.com/quake-4/cheats/

The icon code is `i###` where `#` is in `[0-9a-z]`. Well, the whole alphabet is probably not used but I'm bored.

I added the doom3 “_`^^` is empty string_” flag. I read somewhere that:

> Before typing in the name of your game/player type "^" without quotes and a number 1-0. Once typed, it will disappear and the cursor will change colors, indicating you did it correctly. You can use some letters too, but all the colors are in the numbers.

So I filtered both alpha and numeric codes, see:
https://steamcommunity.com/sharedfiles/filedetails/?id=386113217

