### PR TITLE
Add -DWITH_QSTATCFG so users can provide an alternate qstat.cfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ if (NOT WITH_QSTAT)
     set (WITH_QSTAT "qstat")
 endif (NOT WITH_QSTAT)
 
+if (NOT WITH_QSTATCFG)
+  set (QSTATCFG "${CMAKE_SOURCE_DIR}/src/qstat.cfg")
+else ()
+  add_definitions (-DQSTAT_CFG="${WITH_QSTATCFG}")
+endif (NOT WITH_QSTATCFG)
+
 add_definitions (-DQSTAT_EXEC="${WITH_QSTAT}")
 
 if (CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -588,7 +594,9 @@ endforeach (SIZE ${icon_SIZE})
 install (FILES ${CMAKE_SOURCE_DIR}/pixmaps/scalable/xqf.svg DESTINATION ${PIXMAPS_ENTRY_PATH}/scalable/apps)
 
 # Config
-install (FILES ${CMAKE_SOURCE_DIR}/src/qstat.cfg DESTINATION ${PACKAGE_DATA_DIR})
+if (NOT WITH_QSTATCFG)
+  install (FILES "${QSTATCFG}" DESTINATION ${PACKAGE_DATA_DIR})
+endif (NOT WITH_QSTATCFG)
 
 # Man pages
 install (FILES ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.6 DESTINATION ${MAN_ENTRY_PATH}/man6)

--- a/src/xqf.c
+++ b/src/xqf.c
@@ -2683,7 +2683,11 @@ int main (int argc, char *argv[]) {
 	add_pixmap_path_for_theme ("default");
 	add_pixmap_directory (xqf_PACKAGE_DATA_DIR);
 
+#ifdef QSTAT_CFG
+	qstat_configfile = g_build_filename (QSTAT_CFG, NULL);
+#else
 	qstat_configfile = g_build_filename (xqf_PACKAGE_DATA_DIR, "qstat.cfg", NULL);
+#endif
 
 	dns_gtk_init ();
 


### PR DESCRIPTION
This addresses an issue on Debian where the git version of `qstat.cfg` breaks the refresh functionality for servers when used in conjunction with the packages qstat `quakestat`.

A Master server list will populate but xqf cannot refresh any information for individual servers.

Output to console is:
`/usr/local/share/xqf/qstat.cfg line 487: Unknown extend game type "tf"`

This is due the packaged version of qstat (2.15-4) on Debian not supporting Titanfall and subsequently cannot extend TF for TF2 as required by the xqf included `qstat.cfg`.

Debian users can now compile with `-DWITH_QSTATCFG=/etc/qstat.cfg` to use the packaged config which doesn't include `quakestat` unsupported games from the upstream project.

e.g. `cmake -DWITH_QSTAT=/usr/bin/quakestat -DWITH_QSTATCFG=/etc/qstat.cfg -DCMAKE_INSTALL_PREFIX=/usr ..`
