### PR TITLE
Preferences: remove gtkrc, toolbar style and tooltip options

### DIFF
--- a/src/pref.c
+++ b/src/pref.c
@@ -124,8 +124,6 @@ char *sound_stop = NULL;
 char *sound_server_connect = NULL;
 char *sound_redial_success = NULL;
 
-gboolean use_custom_gtkrc;
-
 GtkTooltips *tooltips;
 
 static int pref_q1_top_color;
@@ -181,7 +179,6 @@ static GtkWidget *refresh_sorts_check_button;
 static GtkWidget *refresh_on_update_check_button;
 static GtkWidget *resolve_on_update_check_button;
 static GtkWidget *show_only_configured_games_check_button;
-static GtkWidget *use_custom_gtkrc_check_button;
 
 static GtkWidget *pushlatency_mode_radio_buttons[3];
 static GtkWidget *pushlatency_value_spinner;
@@ -1238,11 +1235,6 @@ static void get_new_defaults (void) {
 	i = GTK_TOGGLE_BUTTON (show_only_configured_games_check_button)->active;
 	if (i != default_show_only_configured_games) {
 		config_set_bool ("show only configured games", default_show_only_configured_games = i);
-	}
-
-	i = GTK_TOGGLE_BUTTON (use_custom_gtkrc_check_button)->active;
-	if (i != use_custom_gtkrc) {
-		config_set_bool ("use custom gtkrc", use_custom_gtkrc = i);
 	}
 
 	config_pop_prefix();
@@ -3813,24 +3805,6 @@ static GtkWidget *appearance_options_page (void) {
 
 	gtk_widget_show (hbox);
 
-	/* gtkrc */
-
-	hbox = gtk_hbox_new (FALSE, 4);
-	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
-
-	use_custom_gtkrc_check_button = gtk_check_button_new_with_label (_("Use custom color settings"));
-
-	gtk_tooltips_set_tip (tooltips, use_custom_gtkrc_check_button, _("Use XQF's"
-				" color settings instead of the system ones. You need to restart XQF"
-				" for this setting to take effect. Note that you may need to install"
-				" the gtk-engines package."), NULL);
-
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (use_custom_gtkrc_check_button), use_custom_gtkrc);
-	gtk_box_pack_start (GTK_BOX (hbox), use_custom_gtkrc_check_button, FALSE, FALSE, 0);
-	gtk_widget_show (use_custom_gtkrc_check_button);
-
-
-	gtk_widget_show (hbox);
 
 	gtk_widget_show (vbox);
 	gtk_widget_show (frame);
@@ -4635,41 +4609,6 @@ void free_user_info (void) {
 	}
 }
 
-#define XQF_GTKRCNAME "gtkrc-2.0"
-
-static void set_style() {
-	char path[PATH_MAX];
-	int deflt = 0;
-
-	use_custom_gtkrc = config_get_bool_with_default("use custom gtkrc=true", &deflt);
-
-	/** do not apply custom colors in GTK2 by default */
-	if (deflt) {
-		use_custom_gtkrc = FALSE;
-	}
-
-	if (use_custom_gtkrc) {
-		if (default_icontheme) {
-			snprintf(path, sizeof(path), "%s/%s/" XQF_GTKRCNAME, default_icontheme, xqf_PACKAGE_DATA_DIR);
-
-			if (access(path, R_OK) != 0) {
-				path[0] = '\0';
-			}
-		}
-		else {
-			path[0] = '\0';
-		}
-
-		if (!*path) {
-			snprintf(path, sizeof(path), "%s/default/" XQF_GTKRCNAME, xqf_PACKAGE_DATA_DIR);
-		}
-
-		if (access(path, R_OK) == 0) {
-			gtk_rc_parse(path);
-		}
-	}
-}
-
 static void prefs_load_for_game(enum server_type type) {
 	char buf[256];
 	struct game *g = &games[type];
@@ -4844,8 +4783,6 @@ int prefs_load (void) {
 	default_resolve_on_update =             config_get_bool("resolve on update=false");
 	default_show_only_configured_games =    config_get_bool("show only configured games=false");
 	default_icontheme =                     config_get_string("icontheme");
-
-	set_style();
 
 	config_pop_prefix();
 

--- a/src/pref.c
+++ b/src/pref.c
@@ -99,7 +99,6 @@ int default_auto_favorites;
 int default_auto_maps;
 int skip_startup_mapscan;
 int default_toolbar_style;
-int default_toolbar_tips;
 int default_refresh_sorts;
 int default_refresh_on_update;
 int default_resolve_on_update;
@@ -173,7 +172,6 @@ static GtkWidget *auto_maps_check_button;
 static GtkWidget *show_hostnames_check_button;
 static GtkWidget *show_defport_check_button;
 static GtkWidget *toolbar_style_radio_buttons[3];
-static GtkWidget *toolbar_tips_check_button;
 static GtkWidget *countbots_check_button;
 static GtkWidget *refresh_sorts_check_button;
 static GtkWidget *refresh_on_update_check_button;
@@ -1207,11 +1205,6 @@ static void get_new_defaults (void) {
 		}
 	}
 
-	i = GTK_TOGGLE_BUTTON (toolbar_tips_check_button)->active;
-	if (i != default_toolbar_tips) {
-		config_set_bool ("toolbar tips", default_toolbar_tips = i);
-	}
-
 	i = GTK_TOGGLE_BUTTON (countbots_check_button)->active;
 	if (i != serverlist_countbots) {
 		config_set_bool ("count bots", serverlist_countbots = i);
@@ -1447,14 +1440,6 @@ static void ok_callback (GtkWidget *widget, GtkWidget* window) {
 	// Refresh list of sources on screen in case the 'Show only configured games'
 	// setting has changes, or a game command line has been added or removed.
 	refresh_source_list();
-
-	// Enable / disable tooltips after config change
-	if (default_toolbar_tips) {
-		gtk_tooltips_enable(tooltips);
-	}
-	else {
-		gtk_tooltips_disable(tooltips);
-	}
 }
 
 static void update_q1_skin (void) {
@@ -3830,13 +3815,6 @@ static GtkWidget *appearance_options_page (void) {
 
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (toolbar_style_radio_buttons[default_toolbar_style]), TRUE);
 
-	/* Toolbar Tips */
-
-	toolbar_tips_check_button = gtk_check_button_new_with_label (_("Tooltips"));
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (toolbar_tips_check_button), default_toolbar_tips);
-	gtk_box_pack_end (GTK_BOX (hbox), toolbar_tips_check_button, FALSE, FALSE, 0);
-	gtk_widget_show (toolbar_tips_check_button);
-
 	gtk_widget_show (hbox);
 	gtk_widget_show (frame);
 
@@ -4777,7 +4755,6 @@ int prefs_load (void) {
 	show_default_port =                     config_get_bool("show default port=true");
 	serverlist_countbots =                  config_get_bool("count bots=true");
 	default_toolbar_style =                 config_get_int("toolbar style=2");
-	default_toolbar_tips =                  config_get_bool("toolbar tips=true");
 	default_refresh_sorts =                 config_get_bool("sort on refresh=true");
 	default_refresh_on_update =             config_get_bool("refresh on update=true");
 	default_resolve_on_update =             config_get_bool("resolve on update=false");

--- a/src/pref.c
+++ b/src/pref.c
@@ -3780,19 +3780,6 @@ static GtkWidget *appearance_options_page (void) {
 	gtk_widget_show (vbox);
 	gtk_widget_show (frame);
 
-
-	/* Toolbar */
-
-	frame = gtk_frame_new (_("Toolbar"));
-	gtk_box_pack_start (GTK_BOX (page_vbox), frame, FALSE, FALSE, 0);
-
-	hbox = gtk_hbox_new (FALSE, 4);
-	gtk_container_set_border_width (GTK_CONTAINER (hbox), 6);
-	gtk_container_add (GTK_CONTAINER (frame), hbox);
-
-	gtk_widget_show (hbox);
-	gtk_widget_show (frame);
-
 	gtk_widget_show (page_vbox);
 
 	return page_vbox;

--- a/src/pref.c
+++ b/src/pref.c
@@ -98,7 +98,6 @@ int default_save_plrinfo;
 int default_auto_favorites;
 int default_auto_maps;
 int skip_startup_mapscan;
-int default_toolbar_style;
 int default_refresh_sorts;
 int default_refresh_on_update;
 int default_resolve_on_update;
@@ -171,7 +170,6 @@ static GtkWidget *auto_maps_check_button;
 
 static GtkWidget *show_hostnames_check_button;
 static GtkWidget *show_defport_check_button;
-static GtkWidget *toolbar_style_radio_buttons[3];
 static GtkWidget *countbots_check_button;
 static GtkWidget *refresh_sorts_check_button;
 static GtkWidget *refresh_on_update_check_button;
@@ -1195,15 +1193,6 @@ static void get_new_defaults (void) {
 	/* Appearance */
 
 	config_push_prefix ("/" CONFIG_FILE "/Appearance");
-
-	for (i = 0; i < 3; i++) {
-		if (GTK_TOGGLE_BUTTON (toolbar_style_radio_buttons[i])->active) {
-			if (i != default_toolbar_style) {
-				config_set_int  ("toolbar style", default_toolbar_style = i);
-			}
-			break;
-		}
-	}
 
 	i = GTK_TOGGLE_BUTTON (countbots_check_button)->active;
 	if (i != serverlist_countbots) {
@@ -3688,9 +3677,6 @@ static GtkWidget *appearance_options_page (void) {
 	GtkWidget *frame;
 	GtkWidget *hbox;
 	GtkWidget *vbox;
-	GSList *group = NULL;
-	static const char *toolbar_styles[] = { N_("Icons"), N_("Text"), N_("Both") };
-	int i;
 
 	page_vbox = gtk_vbox_new (FALSE, 4);
 	gtk_container_set_border_width (GTK_CONTAINER (page_vbox), 8);
@@ -3803,17 +3789,6 @@ static GtkWidget *appearance_options_page (void) {
 	hbox = gtk_hbox_new (FALSE, 4);
 	gtk_container_set_border_width (GTK_CONTAINER (hbox), 6);
 	gtk_container_add (GTK_CONTAINER (frame), hbox);
-
-	/* Toolbar Style */
-
-	for (i = 0; i < 3; i++) {
-		toolbar_style_radio_buttons[i] = gtk_radio_button_new_with_label (group, _(toolbar_styles[i]));
-		group = gtk_radio_button_group (GTK_RADIO_BUTTON (toolbar_style_radio_buttons[i]));
-		gtk_box_pack_start (GTK_BOX (hbox), toolbar_style_radio_buttons[i], FALSE, FALSE, 0);
-		gtk_widget_show (toolbar_style_radio_buttons[i]);
-	}
-
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (toolbar_style_radio_buttons[default_toolbar_style]), TRUE);
 
 	gtk_widget_show (hbox);
 	gtk_widget_show (frame);
@@ -4754,7 +4729,6 @@ int prefs_load (void) {
 	show_hostnames =                        config_get_bool("show hostnames=true");
 	show_default_port =                     config_get_bool("show default port=true");
 	serverlist_countbots =                  config_get_bool("count bots=true");
-	default_toolbar_style =                 config_get_int("toolbar style=2");
 	default_refresh_sorts =                 config_get_bool("sort on refresh=true");
 	default_refresh_on_update =             config_get_bool("refresh on update=true");
 	default_resolve_on_update =             config_get_bool("resolve on update=false");

--- a/src/pref.h
+++ b/src/pref.h
@@ -90,7 +90,6 @@ extern int default_save_plrinfo;
 extern int default_auto_favorites;
 extern int default_always_resolve;
 extern int default_toolbar_style;
-extern int default_toolbar_tips;
 extern int default_refresh_sorts;
 extern int default_refresh_on_update;
 extern int default_resolve_on_update;

--- a/src/pref.h
+++ b/src/pref.h
@@ -89,7 +89,6 @@ extern int default_save_srvinfo;
 extern int default_save_plrinfo;
 extern int default_auto_favorites;
 extern int default_always_resolve;
-extern int default_toolbar_style;
 extern int default_refresh_sorts;
 extern int default_refresh_on_update;
 extern int default_resolve_on_update;

--- a/src/rc.c
+++ b/src/rc.c
@@ -82,7 +82,6 @@ static struct keyword  keywords[] = {
 	{ "autofavorites",	KEYWORD_BOOL,	"/" CONFIG_FILE "/General/refresh favorites" },
 
 	{ "tb_style",		KEYWORD_INT,	"/" CONFIG_FILE "/Appearance/toolbar style" },
-	{ "tb_tips",		KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/toolbar tips" },
 
 	{ "sort_on_refresh",	KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/sort on refresh" },
 	{ "ref_on_update",	KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/refresh on update" },

--- a/src/rc.c
+++ b/src/rc.c
@@ -81,8 +81,6 @@ static struct keyword  keywords[] = {
 
 	{ "autofavorites",	KEYWORD_BOOL,	"/" CONFIG_FILE "/General/refresh favorites" },
 
-	{ "tb_style",		KEYWORD_INT,	"/" CONFIG_FILE "/Appearance/toolbar style" },
-
 	{ "sort_on_refresh",	KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/sort on refresh" },
 	{ "ref_on_update",	KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/refresh on update" },
 	{ "alwaysresolve",	KEYWORD_BOOL,	"/" CONFIG_FILE "/Appearance/show hostnames" },

--- a/src/xqf-ui.c
+++ b/src/xqf-ui.c
@@ -589,15 +589,14 @@ int calculate_clist_row_height (GtkWidget *clist, GdkPixmap *pixmap) {
 }
 #endif
 
-void set_toolbar_appearance (GtkToolbar *toolbar, int style, int tips) {
+void set_toolbar_appearance (GtkToolbar *toolbar, int style) {
 	switch (style) {
 		case 0: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_ICONS); break;
 		case 1: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_TEXT);  break;
 		case 2: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_BOTH);  break;
 		default: break;
 	}
-
-	gtk_toolbar_set_tooltips (toolbar, tips);
+	gtk_toolbar_set_tooltips(toolbar, TRUE);
 }
 
 /*******************************  Progress Bar  *****************************/

--- a/src/xqf-ui.c
+++ b/src/xqf-ui.c
@@ -589,13 +589,8 @@ int calculate_clist_row_height (GtkWidget *clist, GdkPixmap *pixmap) {
 }
 #endif
 
-void set_toolbar_appearance (GtkToolbar *toolbar, int style) {
-	switch (style) {
-		case 0: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_ICONS); break;
-		case 1: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_TEXT);  break;
-		case 2: gtk_toolbar_set_style (toolbar, GTK_TOOLBAR_BOTH);  break;
-		default: break;
-	}
+void set_toolbar_appearance (GtkToolbar *toolbar) {
+	gtk_toolbar_set_style(toolbar, GTK_TOOLBAR_BOTH);
 	gtk_toolbar_set_tooltips(toolbar, TRUE);
 }
 

--- a/src/xqf-ui.h
+++ b/src/xqf-ui.h
@@ -101,7 +101,7 @@ extern void source_ctree_select_source (struct master *m);
 
 extern int calculate_clist_row_height (GtkWidget *clist, GdkPixmap *pixmap);
 
-extern void set_toolbar_appearance (GtkToolbar *toolbar, int style);
+extern void set_toolbar_appearance (GtkToolbar *toolbar);
 
 extern GtkWidget *create_progress_bar (void);
 extern void progress_bar_reset (GtkWidget *pbar);

--- a/src/xqf-ui.h
+++ b/src/xqf-ui.h
@@ -101,7 +101,7 @@ extern void source_ctree_select_source (struct master *m);
 
 extern int calculate_clist_row_height (GtkWidget *clist, GdkPixmap *pixmap);
 
-extern void set_toolbar_appearance (GtkToolbar *toolbar, int style, int tips);
+extern void set_toolbar_appearance (GtkToolbar *toolbar, int style);
 
 extern GtkWidget *create_progress_bar (void);
 extern void progress_bar_reset (GtkWidget *pbar);

--- a/src/xqf.c
+++ b/src/xqf.c
@@ -379,7 +379,7 @@ void server_filter_select_callback (GtkWidget *widget, int number) {
 
 void start_preferences_dialog (GtkWidget *widget, int page_num) {
 	preferences_dialog (page_num);
-	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style, default_toolbar_tips);
+	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style);
 }
 
 
@@ -2154,7 +2154,7 @@ void populate_main_toolbar (void) {
 		gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (filter_buttons[i]), ((cur_filter & mask) != 0)? TRUE : FALSE);
 	}
 
-	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style, default_toolbar_tips);
+	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style);
 }
 
 	// build server filter menu for toolbar
@@ -2406,12 +2406,7 @@ void populate_main_window (void) {
 
 	// Set tooltips - also in prefs_load
 	tooltips = gtk_tooltips_new ();
-	if (default_toolbar_tips) {
-		gtk_tooltips_enable (tooltips);
-	}
-	else {
-		gtk_tooltips_disable (tooltips);
-	}
+	gtk_tooltips_enable (tooltips);
 
 	gtk_widget_grab_focus (entry);
 }

--- a/src/xqf.c
+++ b/src/xqf.c
@@ -379,7 +379,7 @@ void server_filter_select_callback (GtkWidget *widget, int number) {
 
 void start_preferences_dialog (GtkWidget *widget, int page_num) {
 	preferences_dialog (page_num);
-	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style);
+	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")));
 }
 
 
@@ -2154,7 +2154,7 @@ void populate_main_toolbar (void) {
 		gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (filter_buttons[i]), ((cur_filter & mask) != 0)? TRUE : FALSE);
 	}
 
-	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")), default_toolbar_style);
+	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")));
 }
 
 	// build server filter menu for toolbar

--- a/src/xqf.c
+++ b/src/xqf.c
@@ -379,7 +379,6 @@ void server_filter_select_callback (GtkWidget *widget, int number) {
 
 void start_preferences_dialog (GtkWidget *widget, int page_num) {
 	preferences_dialog (page_num);
-	set_toolbar_appearance (GTK_TOOLBAR (gtk_builder_get_object (builder, "main-toolbar")));
 }
 
 


### PR DESCRIPTION
Preferences: remove gtkrc, toolbar style and tooltip customization.

Just use good default ones: default theme, icon + text toolbar, tooltips enabled.

Also gtkrc is GTK2 only anyway.