### PR TITLE
Fixes unvanquished home path and levelshot lookup

### DIFF
--- a/src/games.xml
+++ b/src/games.xml
@@ -1020,7 +1020,7 @@
 		<config_is_valid>config_is_valid_generic</config_is_valid>
 		<init_maps>unvanquished_init_maps</init_maps>
 		<command>unvanquished</command>
-		<default_home>~/.unvanquished</default_home>
+		<default_home>~/.local/share/unvanquished</default_home>
 		<prefs_load>q3_prefs_load_common</prefs_load>
 		<update_prefs>q3_update_prefs</update_prefs>
 		<main_mod>pkg</main_mod>

--- a/src/q3maps.c
+++ b/src/q3maps.c
@@ -197,7 +197,9 @@ static char* is_q3_mapshot(const char* name) {
 }
 
 static char* is_unvanquished_mapshot(const char* name) {
-	gchar *mapname;
+	// Name in the form meta/<mapname>/<mapname>.<ext>
+
+	gchar *metaname, *mapname;
 	debug(4, "check %s", name);
 	if (*name == '/')
 		name = last_two_entries(name);
@@ -205,8 +207,19 @@ static char* is_unvanquished_mapshot(const char* name) {
 	if (g_ascii_strncasecmp(name, "meta/", 5))
 		return NULL;
 
-	if ((mapname = has_known_image_format(name + 5))) {
+	if ((metaname = has_known_image_format(name + 5))) {
 		debug(3, "found: %s", name);
+
+		gchar* sep = strchr(metaname, '/');
+
+		if (sep == NULL) {
+			return NULL;
+		}
+
+		gchar *next = sep + 1;
+		mapname = g_strndup(next, strlen(metaname) - (next - metaname));
+		g_free(metaname);
+
 		return mapname;
 	}
 


### PR DESCRIPTION
Fixes unvanquished home path and levelshot lookup.

This doesn't really work yet before CRN loading is implemented, that's why I didn't cared that much about it.

- The default home path has changed long time ago, we don't have `xdg_home_dir` resolution yet so for now it assumes the default path.
- I also noticed a bug in the levelshot lookup, until I implemented CRN loading I could not notice it was not working, this is now fixed.

Includes #240 to please the CI:

- https://github.com/XQF/xqf/pull/240