### PR TITLE
Implement CRN/DDS/KTX levelshot loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y qstat intltool cmake libgtk2.0-dev libgeoip-dev libminizip-dev
+    - name: Update submodules
+      run: git submodule update --init --recursive
     - name: cmake
       run: CC=gcc CXX=g++ cmake -DWITH_QSTAT=/usr/bin/quakestat -DCMAKE_C_FLAGS=-Werror .
     - name: make
@@ -27,6 +29,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y qstat intltool cmake libgtk2.0-dev libgeoip-dev libminizip-dev
+    - name: Update submodules
+      run: git submodule update --init --recursive
     - name: cmake
       run: CC=clang CXX=clang++ cmake -DWITH_QSTAT=/usr/bin/quakestat -DCMAKE_C_FLAGS=-Werror .
     - name: make

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/crunch"]
+	path = libs/crunch
+	url = https://github.com/DaemonEngine/crunch.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ option(DEPRECATED_DISABLE "Disable deprecated parts of GLib, GObject, GDK and GT
 
 option(USE_GEOIP "Depend on GeoIP library for geolocation" ON)
 option(USE_GZIP "Enable gzip compressor support" ON)
+option(USE_CRUNCH "Enable Crunch decompressor support (DDS, KTX, CRN)" ON)
 option(RCON_STANDALONE "Build standalone RCON" OFF)
 
 if (NOT WITH_QSTAT)
@@ -145,6 +146,7 @@ set (xqf_SOURCES
      ${CMAKE_SOURCE_DIR}/src/loadpixmap.c
      ${CMAKE_SOURCE_DIR}/src/scripts.c
      ${CMAKE_SOURCE_DIR}/src/memtopixmap.c
+     ${CMAKE_SOURCE_DIR}/src/crntotga.cpp
 
      ${CMAKE_SOURCE_DIR}/src/addmaster.h
      ${CMAKE_SOURCE_DIR}/src/addserver.h
@@ -190,6 +192,7 @@ set (xqf_SOURCES
      ${CMAKE_SOURCE_DIR}/src/loadpixmap.h
      ${CMAKE_SOURCE_DIR}/src/scripts.h
      ${CMAKE_SOURCE_DIR}/src/memtopixmap.h
+     ${CMAKE_SOURCE_DIR}/src/crntotga.h
      )
 
 set (flag_DATA
@@ -534,6 +537,21 @@ endif (GUI MATCHES GTK3)
 if (USE_GEOIP)
     target_link_libraries (xqf GeoIP)
 endif (USE_GEOIP)
+
+if (USE_CRUNCH)
+	set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+	set(BUILD_CRUNCH OFF)
+	set(BUILD_EXAMPLES OFF)
+	set(BUILD_SHARED_LIBCRN OFF)
+	set(BUILD_STATIC_LIBCRN ON)
+
+	add_subdirectory(${CMAKE_SOURCE_DIR}/libs/crunch)
+
+	target_include_directories(xqf PRIVATE ${CMAKE_SOURCE_DIR}/libs/crunch/crnlib)
+	target_link_directories(xqf PRIVATE ${CMAKE_BINARY_DIR}/libs/crunch/crnlib)
+    target_link_libraries(xqf crn)
+endif()
 
 if (RCON_STANDALONE)
     target_link_libraries (xqf -lreadline)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ INSTALLATION
 [![Build](https://github.com/XQF/xqf/actions/workflows/build.yml/badge.svg)](https://github.com/XQF/xqf/actions/workflows/build.yml)
 
 ```sh
-git clone https://github.com/XQF/xqf.git
+git clone --recurse-submodules https://github.com/XQF/xqf.git
 cd xqf
 mkdir build
 cd build
 cmake ..
 make
 make install
+```
+
+If you already cloned, you can fetch the submodule after entring the `xqf` folder this way:
+
+```sh
+git submodule update --init --recursive
 ```
 
 On Debian or Ubuntu, use ``cmake -DWITH_QSTAT=/usr/bin/quakestat -DCMAKE_INSTALL_PREFIX=/usr ..``.
@@ -70,11 +76,11 @@ HISTORY
 
 XQF was originally written by Roman Pozlevich in 1998. It has been maintained and improved by a devoted team over the years with following major developers:
 
-1998-2000 Roman Pozlevich <hidden email="roma@botik.ru"/>  
-2000-2002 Bill Adams <hidden email="bill@evilbill.org"/>  
-2000-2003 Alex Burger <hidden email="alex_b@users.sf.net"/>  
-2001-2010 Ludwig Nussel <hidden email="ludwig.nussel@suse.de"/>  
-2001-2015 Jordi Mallach <hidden email="jordi@debian.org"/>  
-2015-2015 Artem Vorotnikov <hidden email="artem@vorotnikov.me"/>  
-2014-2024 Zack Middleton <hidden email="zturtleman@gmail.com"/>  
-2013-2024 Thomas Debesse <hidden email="dev@illwieckz.net"/>  
+1998-2000 Roman Pozlevich <hidden email="roma [ad] botik.ru"/>  
+2000-2002 Bill Adams <hidden email="bill [ad] evilbill.org"/>  
+2000-2003 Alex Burger <hidden email="alex_b [ad] users.sf.net"/>  
+2001-2010 Ludwig Nussel <hidden email="ludwig.nussel [ad] suse.de"/>  
+2001-2015 Jordi Mallach <hidden email="jordi [ad] debian.org"/>  
+2015-2015 Artem Vorotnikov <hidden email="artem [ad] vorotnikov.me"/>  
+2014-2024 Zack Middleton <hidden email="zturtleman [ad] gmail.com"/>  
+2013-2025 Thomas Debesse <hidden email="dev [ad] illwieckz.net"/>  

--- a/src/crntotga.cpp
+++ b/src/crntotga.cpp
@@ -1,0 +1,96 @@
+#include "crn_core.h"
+#include "crn_buffer_stream.h"
+#include "crn_texture_conversion.h"
+#include "crn_stb_image.cpp"
+#include "crntotga.h"
+#include <cstdio>
+
+unsigned int written_size;
+
+void write_buffer(void* context, void* data, int size)
+{
+	memcpy((char*) context + written_size, data, size);
+	written_size += size;
+}
+
+unsigned char* convert_crn_tga(const unsigned char* input_data, const unsigned int input_size, enum crunchFormat_t format, unsigned int *output_size)
+{
+	crnlib::texture_file_types::format src_file_format;
+
+	switch (format)
+	{
+		case CRUNCH_CRN:
+			src_file_format = crnlib::texture_file_types::cFormatCRN;
+			break;
+		case CRUNCH_DDS:
+			src_file_format = crnlib::texture_file_types::cFormatDDS;
+			break;
+		case CRUNCH_KTX:
+			src_file_format = crnlib::texture_file_types::cFormatKTX;
+			break;
+		default:
+			return nullptr;
+	}
+
+	crnlib::buffer_stream in_stream(input_data, input_size);
+	crnlib::data_stream_serializer serializer(in_stream);
+
+	crnlib::mipmapped_texture work_tex;
+	if (!work_tex.read_from_stream(serializer, src_file_format))
+	{
+		return nullptr;
+	}
+
+	crnlib::texture_conversion::convert_params convert_params;
+
+	if (!work_tex.convert(crnlib::PIXEL_FMT_A8R8G8B8, crnlib::dxt_image::pack_params()))
+	{
+		return nullptr;
+	}
+
+	crnlib::image_u8 tmp;
+	crnlib::image_u8* img = work_tex.get_level_image(0, 0, tmp);
+
+	int width = work_tex.get_width();
+	int height = work_tex.get_height();
+
+	// HACK: Enough size for the RGBA pixmap + header + footer.
+	int scratch_size = 1000 + (4 * width * height);
+	unsigned char *scratch_data = (unsigned char*) malloc(scratch_size);
+
+	if (!scratch_data)
+	{
+		return nullptr;
+	}
+
+	// Disable RLE compression to be faster.
+	stbi_write_tga_with_rle = 0;
+
+	written_size = 0;
+
+	if (!stbi_write_tga_to_func(&write_buffer, scratch_data, work_tex.get_width(), work_tex.get_height(), 4, img->get_ptr()))
+	{
+		free(scratch_data);
+		return nullptr;
+	}
+
+	unsigned char *output_data = (unsigned char*) malloc(written_size);
+
+	if (!output_data)
+	{
+		free(scratch_data);
+		return nullptr;
+	}
+
+	memcpy(output_data, scratch_data, written_size);
+	*output_size = written_size;
+
+#if 0
+	FILE* output_file = fopen("/tmp/output.tga", "w+");
+	fwrite(output_data, written_size, 1, output_file);
+	fclose(output_file);
+#endif
+
+	free(scratch_data);
+	return output_data;
+}

--- a/src/crntotga.h
+++ b/src/crntotga.h
@@ -1,0 +1,17 @@
+enum crunchFormat_t
+{
+	CRUNCH_NONE,
+	CRUNCH_CRN,
+	CRUNCH_DDS,
+	CRUNCH_KTX,
+};
+
+#ifdef __cplusplus
+#define EXTERNC extern "C"
+#else
+#define EXTERNC
+#endif
+
+EXTERNC unsigned char* convert_crn_tga(const unsigned char* input_data, const unsigned int input_size, enum crunchFormat_t format, unsigned int *output_size);
+
+#undef EXTERNC


### PR DESCRIPTION
Implement CRN/DDS/KTX levelshot loading

Unvanquished requires #238 to get it working:

- https://github.com/XQF/xqf/pull/238

Since the existing code relies on GdkPixbuf for processing the images, the laziest way to do it was to implement a CRN/DDS/KTX to TGA conversion with crnlib and feed the TGA to GdkPixbuf.

Also includes #240 to please the CI:

- https://github.com/XQF/xqf/pull/240