### PR TITLE
Various compilation fixes

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -297,7 +297,8 @@ static void worker_parse_callback (char *str, void *data) {
 
 	len = strlen (str);
 	str[len] = '\n';
-	write (1, str, len + 1);    /* stdout */
+	// HACK: Silence: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’.
+	if (write (1, str, len + 1)) {}    /* stdout */
 }
 
 
@@ -788,7 +789,8 @@ void dns_cancel_requests (void) {
 	dns_set_callback (NULL, NULL);
 
 	if (dns_helper.output >= 0) {
-		write (dns_helper.output, cmd, sizeof (cmd) - 1);
+		// HACK: Silence: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’.
+		if (write (dns_helper.output, cmd, sizeof (cmd) - 1)) {}
 	}
 }
 
@@ -804,7 +806,8 @@ void dns_lookup (const char *str) {
 		strcpy (host, str);
 		host[len] = '\n';
 		host[len + 1] = '\0';
-		write (dns_helper.output, host, len + 1);
+		// HACK: Silence: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’.
+		if (write (dns_helper.output, host, len + 1)) {}
 	}
 }
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -1122,7 +1122,7 @@ static void server_filter_fill_widgets(guint num) {
 				f_number=g_array_index(filter->countries,int,i);
 
 				// gtk_clist_insert third parameter is not const!
-				strncpy(buf,geoip_name_by_id(f_number),sizeof(buf));
+				strncpy(buf,geoip_name_by_id(f_number),sizeof(buf) - 1);
 				gtk_clist_insert(GTK_CLIST(country_filter_list), rw, text);
 				countrypix = get_pixmap_for_country_with_fallback(f_number);
 				if (countrypix) {
@@ -1681,7 +1681,7 @@ static void country_add_selection_to_right_list() {
 	countrypix = get_pixmap_for_country(flag_id);
 
 	// gtk_clist_insert third parameter is not const!
-	strncpy (buf,geoip_name_by_id (flag_id), sizeof (buf));
+	strncpy (buf,geoip_name_by_id (flag_id), sizeof (buf) - 1);
 	gtk_clist_append (GTK_CLIST (country_right_list), text);
 	if (countrypix) {
 		gtk_clist_set_pixtext (GTK_CLIST (country_right_list), last_row_right_list, 0, geoip_name_by_id (flag_id), 4, countrypix->pix, countrypix->mask);
@@ -1749,7 +1749,7 @@ static void country_selection_on_ok(void) {
 		countrypix = get_pixmap_for_country(country_nr);
 
 		// gtk_clist_insert third parameter is not const!
-		strncpy(buf,geoip_name_by_id(country_nr),sizeof(buf));
+		strncpy(buf,geoip_name_by_id(country_nr),sizeof(buf) - 1);
 		gtk_clist_insert(GTK_CLIST(country_filter_list), i, text);
 		if (countrypix) {
 			gtk_clist_set_pixtext(GTK_CLIST(country_filter_list), i, 0,
@@ -1795,7 +1795,7 @@ static void populate_country_clist(GtkWidget* clist, gboolean all) {
 		++row_number;
 
 		// gtk_clist_insert third parameter is not const!
-		strncpy(buf,geoip_name_by_id(i),sizeof(buf));
+		strncpy(buf,geoip_name_by_id(i),sizeof(buf) - 1);
 		gtk_clist_insert(GTK_CLIST(clist), row_number, text);
 		if (countrypix) {
 			gtk_clist_set_pixtext(GTK_CLIST(clist), row_number, 0,
@@ -1941,7 +1941,7 @@ static void country_create_popup_window(void) {
 		countrypix = get_pixmap_for_country_with_fallback (flag_nr);
 
 		// gtk_clist_insert third parameter is not const!
-		strncpy(buf,geoip_name_by_id (flag_nr), sizeof (buf));
+		strncpy(buf,geoip_name_by_id (flag_nr), sizeof (buf) - 1);
 		gtk_clist_insert (GTK_CLIST (country_right_list), i, text);
 
 		if (countrypix) {
@@ -2058,7 +2058,7 @@ void filter_quick_set (const char* str) {
 	if (str) {
 		unsigned num;
 		size_t max = sizeof (quick_filter_token) / sizeof (quick_filter_token[0]);
-		strncpy (quick_filter_str, str, sizeof (quick_filter_str));
+		strncpy (quick_filter_str, str, sizeof (quick_filter_str) - 1);
 		num = tokenize (quick_filter_str, quick_filter_token, max, " ");
 		if (num < max)
 			quick_filter_token[num] = NULL;

--- a/src/flt-player.c
+++ b/src/flt-player.c
@@ -223,7 +223,7 @@ static struct player_pattern *player_pattern_new (struct player_pattern *src) {
 
 static void pattern_clist_sync_selection (void) {
 	GSList *list;
-	struct player_pattern *pp;
+	struct player_pattern *pp = NULL;
 
 	if (current_row >= 0) {
 		list = g_slist_nth (curplrs, current_row);

--- a/src/launch.c
+++ b/src/launch.c
@@ -307,7 +307,8 @@ int client_launch_exec (int forkit, char *dir, char* argv[], struct server *s) {
 					CLIENT_ERROR_MSG_HEAD, argv[0], g_strerror (errno));
 
 			error_out:
-			write (pipefds[1], msg, strlen (msg) + 1);
+			// HACK: Silence: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’.
+			if (write (pipefds[1], msg, strlen (msg) + 1)) {}
 			close (pipefds[1]);
 
 			on_sig (SIGHUP,  _exit);

--- a/src/srv-list.c
+++ b/src/srv-list.c
@@ -106,7 +106,7 @@ void assemble_server_address (char *buf, int size, const struct server *s) {
 	}
 	else {
 		strncpy (buf, (show_hostnames && s->host->name)?
-				s->host->name : inet_ntoa (s->host->ip), size);
+				s->host->name : inet_ntoa (s->host->ip), size - 1);
 	}
 }
 

--- a/src/srv-list.c
+++ b/src/srv-list.c
@@ -314,7 +314,7 @@ static int player_clist_refresh_row (struct server *s, struct player *p,
 		row = gtk_clist_append (player_clist, text);
 	}
 	else {
-		for (col = 1; col < 7; col++) {
+		for (col = 1; col < 6; col++) {
 			gtk_clist_set_text (player_clist, row, col, text[col]);
 		}
 	}

--- a/src/srv-prop.c
+++ b/src/srv-prop.c
@@ -221,7 +221,9 @@ void props_load (void) {
 		return;
 
 	while (!feof (f)) {
-		fgets (buf, 1024, f);
+		if (!fgets (buf, 1024, f)) {
+			return;
+		}
 
 		if (buf[0] == '\n') {
 			if (p)


### PR DESCRIPTION
Silence some `warn_unused_result` errors.

Fixing it properly would require a deeper revamp, and actually we may want to replace all this code with standard libraries…

Also fixes some “specified bound equals destination size” errors.

Also silence a “may be used uninitialized” warning (misdetected).

And other things like that.