### PR TITLE
Make sure `USE_CRUNCH=OFF` truly disables building the Crunch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,6 @@ set(xqf_SOURCES
 	 ${CMAKE_SOURCE_DIR}/src/loadpixmap.c
 	 ${CMAKE_SOURCE_DIR}/src/scripts.c
 	 ${CMAKE_SOURCE_DIR}/src/memtopixmap.c
-	 ${CMAKE_SOURCE_DIR}/src/crntotga.cpp
 
 	 ${CMAKE_SOURCE_DIR}/src/addmaster.h
 	 ${CMAKE_SOURCE_DIR}/src/addserver.h
@@ -297,8 +296,12 @@ set(xqf_SOURCES
 	 ${CMAKE_SOURCE_DIR}/src/loadpixmap.h
 	 ${CMAKE_SOURCE_DIR}/src/scripts.h
 	 ${CMAKE_SOURCE_DIR}/src/memtopixmap.h
-	 ${CMAKE_SOURCE_DIR}/src/crntotga.h
  )
+
+set(crntotga_SOURCES
+	 ${CMAKE_SOURCE_DIR}/src/crntotga.cpp
+	 ${CMAKE_SOURCE_DIR}/src/crntotga.h
+)
 
 set(flag_DATA
 	${CMAKE_SOURCE_DIR}/pixmaps/flags/lan.png
@@ -625,6 +628,11 @@ add_definitions(-DICONS_C_INCLUDE="${CMAKE_BINARY_DIR}/icons.c")
 # this must be manually specified due to the include name being a define
 set_property(SOURCE ${CMAKE_SOURCE_DIR}/src/game.c
 	APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/games.c)
+
+if (USE_CRUNCH)
+	add_definitions(-DUSE_CRUNCH)
+	list(APPEND xqf_SOURCES ${crntotga_SOURCES})
+endif()
 
 # Compile and link
 add_executable (xqf ${xqf_SOURCES})

--- a/src/q3maps.c
+++ b/src/q3maps.c
@@ -34,7 +34,10 @@
 #include "utils.h"
 
 #include "q3maps.h"
+
+#if defined(USE_CRUNCH)
 #include "crntotga.h"
+#endif
 
 struct q3mapinfo
 {
@@ -156,18 +159,31 @@ static inline const char* last_two_entries(const char* name) {
 	return name;
 }
 
+#define GDKPIXBUF_EXT_NUM 4
+
+#if defined(USE_CRUNCH)
+	#define CRUNCH_EXT_NUM 3
+#else
+	#define CRUNCH_EXT_NUM 0
+#endif
+
+#define PIC_EXT_NUM GDKPIXBUF_EXT_NUM + CRUNCH_EXT_NUM
+
 static gchar* has_known_image_format(const gchar* name) {
-	guint i, ext_num = 7;
-	gchar *ext_list[7] = {
+	guint i, ext_num = PIC_EXT_NUM;
+	gchar *ext_list[PIC_EXT_NUM] = {
 		// Native GdkPixbuf loader.
 		".jpg",
 		".png",
 		".tga",
 		".webp",
+
+#if defined(USE_CRUNCH)
 		// Crunch TGA conversion before GdkPixbuf.
 		".crn",
 		".dds",
 		".ktx",
+#endif
 	};
 
 	for (i = 0; i < ext_num; i++) {
@@ -729,6 +745,7 @@ static size_t readimagefromzip(guchar** buf, const char* zipfile, const char* fi
 
 	if (!error)
 	{
+#if defined(USE_CRUNCH)
 		enum crunchFormat_t format = CRUNCH_NONE;
 
 		if (stri_has_ext(filename, ".crn"))
@@ -758,6 +775,9 @@ static size_t readimagefromzip(guchar** buf, const char* zipfile, const char* fi
 			*buf = tgabuf;
 			return tgabuf_len;
 		}
+#else
+		return buflen;
+#endif
 	}
 
 	g_free(*buf);


### PR DESCRIPTION
Make sure `USE_CRUNCH=OFF` truly disables building the Crunch support.

Fixes #246:

- https://github.com/XQF/xqf/issues/246

This PR is written over #247 for convenience:

- https://github.com/XQF/xqf/pull/247