### PR TITLE
Fix RCON issues: crashes, memory leaks, and display bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,10 @@ if (BUILD_XQF)
 
 	find_package(Gettext REQUIRED)
 
-	pkg_check_modules(UNZIP REQUIRED minizip)
+	pkg_check_modules(UNZIP minizip-ng)
+if(NOT UNZIP_FOUND)
+  pkg_check_modules(UNZIP REQUIRED minizip)
+endif()
 	pkg_check_modules(GTK REQUIRED gtk+-${GTK_TARGET}.0)
 
 	include_directories(${GTK_INCLUDE_DIRS})

--- a/src/config.c
+++ b/src/config.c
@@ -350,13 +350,14 @@ static char *path_concat (const char *str1, const char *str2) {
 
 static struct config_key *parse_path (const char *path,
 		int create,
-		char **defval,
+		const char **defval,
 		struct config_file **file1,
 		struct config_section **section1) {
 	const char *filename;
 	char *secname = NULL;
 	char *keyname = NULL;
-	char *def;
+	const char *def;
+	char *def2;
 	char *buf = NULL;
 	char *ptr = NULL;
 	struct config_file *file;
@@ -384,9 +385,9 @@ static struct config_key *parse_path (const char *path,
 		buf = g_strdup (path);
 	}
 
-	def = strchr (buf, '=');
-	if (def)
-		*def = '\0';
+	def2 = strchr (buf, '=');
+	if (def2)
+		*def2 = '\0';
 
 	filename = ptr = &buf[1];
 
@@ -526,7 +527,7 @@ static char *string_unescape (const char *s) {
 static char *config_get_raw_with_default (const char *path, int *def) {
 	struct config_file *file;
 	struct config_key *key;
-	char *val;
+	const char *val;
 
 	key = parse_path (path, FALSE, &val, &file, NULL);
 	if (key) {
@@ -536,7 +537,7 @@ static char *config_get_raw_with_default (const char *path, int *def) {
 	else {
 		if (def) *def = TRUE;
 	}
-	return val;
+	return (char *)val;
 }
 
 

--- a/src/rcon.c
+++ b/src/rcon.c
@@ -117,7 +117,7 @@ static void rcon_print (char *fmt, ...) {
 		g_vsnprintf (buf, sizeof(buf), fmt, ap);
 		va_end (ap);
 
-		gtk_text_buffer_set_text(rcon_text_buffer, buf, strlen(buf));
+		gtk_text_buffer_insert_at_cursor(rcon_text_buffer, buf, strlen(buf));
 
 		vadjustment = gtk_text_view_get_vadjustment (GTK_TEXT_VIEW (rcon_text));
 		gtk_adjustment_set_value (vadjustment,
@@ -218,7 +218,7 @@ static int rcon_send(const char* cmd) {
 			return -1;
 		}
 
-		rcon_challenge = g_strstrip(msg+strlen(mustresponse));
+		rcon_challenge = g_strdup(g_strstrip(msg+strlen(mustresponse)));
 	}
 
 	if (rcon_servertype == HL_SERVER) {
@@ -437,16 +437,18 @@ static char* rcon_receive() {
 static gboolean rcon_input_callback (GIOChannel *chan, GIOCondition condition,
                                      void *user_data) {
 	GtkAdjustment *vadjustment;
-	char* msg = rcon_receive();
+	char* msg;
 
-	gtk_text_buffer_set_text (rcon_text_buffer, msg, strlen(msg));
+	while (wait_read_timeout(rcon_fd, 0, 50000) > 0) {
+		msg = rcon_receive();
+		gtk_text_buffer_insert_at_cursor (rcon_text_buffer, msg, strlen(msg));
+		g_free(msg);
+	}
 
 	vadjustment = gtk_text_view_get_vadjustment (GTK_TEXT_VIEW (rcon_text));
 	gtk_adjustment_set_value (vadjustment,
 			gtk_adjustment_get_upper (vadjustment) -
 			gtk_adjustment_get_page_size (vadjustment));
-
-	g_free(msg);
 
 	return TRUE;
 }
@@ -523,7 +525,7 @@ void rcon_dialog (const struct server *s, const char *passwd) {
 	if (rcon_challenge)
 		g_free(rcon_challenge);
 	rcon_challenge = NULL;
-	rcon_password = passwd;
+	rcon_password = g_strdup(passwd);
 	rcon_servertype = s->type;
 	rcon_fd = open_connection (&s->host->ip, s->port);
 	if (rcon_fd < 0)

--- a/src/rcon.c
+++ b/src/rcon.c
@@ -57,6 +57,7 @@ static char *packet = NULL;
 static const char* rcon_password = NULL;
 static char* rcon_challenge = NULL;         // halflife challenge
 static enum server_type rcon_servertype;
+static size_t rcon_last_msg_size = 0;
 
 #if defined(BUILD_XQF)
 static struct history *rcon_history = NULL;
@@ -427,6 +428,7 @@ static char* rcon_receive() {
 		}
 
 		msg = msg_terminate (msg, size);
+		rcon_last_msg_size = strlen(msg);
 	}
 
 	return msg;
@@ -441,7 +443,7 @@ static gboolean rcon_input_callback (GIOChannel *chan, GIOCondition condition,
 
 	while (wait_read_timeout(rcon_fd, 0, 50000) > 0) {
 		msg = rcon_receive();
-		gtk_text_buffer_insert_at_cursor (rcon_text_buffer, msg, strlen(msg));
+		gtk_text_buffer_insert_at_cursor (rcon_text_buffer, msg, rcon_last_msg_size);
 		g_free(msg);
 	}
 

--- a/src/source.c
+++ b/src/source.c
@@ -250,7 +250,7 @@ static struct master *find_master_server (char *addr, unsigned short port, char 
 
 static char *unify_url (const char *url) {
 	char *unified, *tmp;
-	char *ptr, *ptr2, *ptr3;
+	const char *ptr, *ptr2, *ptr3;
 	long port;
 	int len;
 
@@ -276,7 +276,7 @@ static char *unify_url (const char *url) {
 		ptr3 = ptr2;
 	}
 	else {
-		port = strtol (ptr2 + 1, &ptr3, 10);
+		port = strtol (ptr2 + 1, (char **)&ptr3, 10);
 		if (port != 80)
 			ptr2 = ptr3;
 	}

--- a/src/utils.c
+++ b/src/utils.c
@@ -137,7 +137,7 @@ int str_isempty (const char *str) {
 
 char *expand_tilde (const char *path) {
 	char *res = NULL;
-	char *slash;
+	const char *slash;
 	char name[MAXNAMELEN];
 	int namelen;
 	struct passwd *pwd;
@@ -796,7 +796,7 @@ char* resolve_path(const char* path) {
 	struct stat statbuf;
 	int length = 0;
 	char buf[256];
-	char *ptr = NULL;
+	const char *ptr = NULL;
 	char *dir = NULL;
 	char* tmp = NULL;
 


### PR DESCRIPTION
- Fix crash when adding RCON password (dangling pointer)
- Duplicate rcon_challenge to prevent invalid memory access
- Add const qualifiers to fix compiler warnings
- Append RCON output instead of replacing (see all plugins)
- Read all available RCON packets in callback loop (fix partial data)