### PR TITLE
fix: initialize msg to NULL in rcon_receive to avoid UB

### DIFF
--- a/src/rcon.c
+++ b/src/rcon.c
@@ -344,7 +344,7 @@ static char* msg_terminate (char *msg, int size) {
 }
 
 static char* rcon_receive() {
-	char *msg;
+	char *msg = NULL;
 	ssize_t t;
 	ssize_t size;
 


### PR DESCRIPTION
In rcon_receive(), `msg` is declared but not initialized. There are two code paths that can leave it indeterminate before it is passed to msg_terminate():

1. DOOM3/Q4 branch: when the received packet has size <= 2+6+4+1 (i.e. the payload is too short to contain a useful message), the `if` body that would assign `msg` is skipped entirely.

2. HW_SERVER branch: when size > PACKET_MAXSIZE the switch breaks out without setting `msg`.

msg_terminate() guards against NULL (`if (!msg || size <= 0) return g_strdup("\n")`), so setting `msg = NULL` makes both paths safe and well-defined.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>